### PR TITLE
Work for SOLPS->Hermes-3 interpolation: radial/poloidal data overhaul

### DIFF
--- a/cli/cmonitor.py
+++ b/cli/cmonitor.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # Reading with cache for extra speed
+import glob
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib as mpl
@@ -14,8 +15,57 @@ from datetime import datetime
 
 
 
+def _is_case_path(path):
+    return os.path.isdir(path) and (
+        os.path.exists(os.path.join(path, "BOUT.inp"))
+        or bool(glob.glob(os.path.join(path, "BOUT.dmp*")))
+    )
 
-def cmonitor(path, save = False, plot = False, table = True, neutrals = False, logfile_plots = False, sep = True):
+
+def _expand_case_paths(path):
+    if isinstance(path, (str, os.PathLike)):
+        raw_paths = [os.fspath(path)]
+    else:
+        raw_paths = [os.fspath(item) for item in path]
+
+    case_paths = []
+    seen = set()
+
+    for raw_path in raw_paths:
+        matches = sorted(glob.glob(raw_path)) if glob.has_magic(raw_path) else [raw_path]
+        matches = [os.path.normpath(match) for match in matches if _is_case_path(match)]
+
+        if not matches:
+            raise FileNotFoundError(f"No case directories match '{raw_path}'")
+
+        for match in matches:
+            if match not in seen:
+                seen.add(match)
+                case_paths.append(match)
+
+    return case_paths
+
+
+def cmonitor(path, save = False, plot = False, table = True, neutrals = False, logfile_plots = False, sep = True, volavg = True):
+    case_paths = _expand_case_paths(path)
+
+    for index, case_path in enumerate(case_paths):
+        if index > 0:
+            print()
+
+        _cmonitor_case(
+            case_path,
+            save=save,
+            plot=plot,
+            table=table,
+            neutrals=neutrals,
+            logfile_plots=logfile_plots,
+            sep=sep,
+            volavg=volavg,
+        )
+
+
+def _cmonitor_case(path, save = False, plot = False, table = True, neutrals = False, logfile_plots = False, sep = True, volavg = True):
     """
     Produce convergence report of 2D Hermes-3 simulation
     Plots of process conditions at OMP and target 
@@ -24,7 +74,7 @@ def cmonitor(path, save = False, plot = False, table = True, neutrals = False, l
     
     Inputs
     -----
-    path: path to case directory
+    path: case path, case paths, or wildcard pattern(s) resolving to case directories
     save: bool, save figure. saved by case name
     sep: bool, if true, show profiles at separatrix, otherwise  last sol ring
     plot: bool, show ploy
@@ -35,7 +85,7 @@ def cmonitor(path, save = False, plot = False, table = True, neutrals = False, l
     if path == ".":
         casename = os.path.basename(os.getcwd())
     else:
-        casename = os.path.basename(path)
+        casename = os.path.basename(os.path.normpath(path))
     print(f"Reading {casename}")
     print("Calculating...", end = "")
 
@@ -162,7 +212,8 @@ def cmonitor(path, save = False, plot = False, table = True, neutrals = False, l
     # ddt
     for param in res:
 
-        res[param] = (res[param] * dv_noguards[None, :, :]) / np.sum(dv_noguards)   # Volume weighted
+        if volavg:
+            res[param] = (res[param] * dv_noguards[None, :, :]) / np.sum(dv_noguards)   # Volume weighted
         res[param] = np.sqrt(np.mean(res[param]**2, axis = (1,2)))  # RMS
         res[param] = np.convolve(res[param], np.ones(1), "same")    # Moving average with window of 1
 
@@ -415,20 +466,22 @@ if __name__ == "__main__":
     
     # Define arguments
     parser = argparse.ArgumentParser(description = "Case monitor")
-    parser.add_argument("path", type=str, help = "Path to case")
+    parser.add_argument("paths", nargs="+", help = "Case path(s) or wildcard pattern(s)")
     parser.add_argument("-p", action="store_true", help = "Plot?")
     parser.add_argument("-t", action="store_true", help = "Table?")
     parser.add_argument("-s", action="store_true", help = "Save figure?")
+    parser.add_argument("-a", action="store_true", help = "Make ddt() plots non-volume averaged?")
     parser.add_argument("-solverdiags", action="store_true", help = "Parse SNES console output?")
     parser.add_argument("-neutrals", action="store_true", help = "Alternative physics quantities")
     parser.add_argument("-sep", action="store_true", help = "Plot profiles at sep (T) or last sol ring (F)?")
     
     # Extract arguments and call function
     args = parser.parse_args()
-    cmonitor(args.path, 
+    cmonitor(args.paths, 
              plot = args.p, 
              table = args.t, 
              save = args.s, 
              neutrals = args.neutrals, 
              sep = args.sep,
-             logfile_plots = args.solverdiags)
+             logfile_plots = args.solverdiags,
+             volavg = not args.a)

--- a/cli/heavyplot.py
+++ b/cli/heavyplot.py
@@ -54,7 +54,7 @@ def heavyplot(casename, save = True):
     lineplot(
         toplot,
         params = ["Te", "Td",  "Ne", "Nd", "Rd+_ex"],
-        regions = ["omp", "outer_lower", "field_line"],
+        regions = ["omp", "outer_lower_target", "field_line"],
         colors = colors,
         save_name = save_name
     )

--- a/cli/heavyplot.py
+++ b/cli/heavyplot.py
@@ -39,6 +39,7 @@ def heavyplot(casename, save = True):
         
     ts = np.linspace(0, tlen-1, tres, dtype = int)
 
+
     colors = [plt.cm.get_cmap("Spectral_r", tres)(x) for x in range(tres)]
 
     toplot = {}
@@ -47,17 +48,23 @@ def heavyplot(casename, save = True):
         toplot[f"t={time_ms:.3f}ms"] = ds.isel(t=t, x = slice(2,-2))
 
     if save is True:
-        save_name = f"mon_{casename}"
+        save_name = f"mon_prof_{casename}"
     else:
         save_name = ""
+
+
 
     lineplot(
         toplot,
         params = ["Te", "Td",  "Ne", "Nd", "Rd+_ex"],
         regions = ["omp", "outer_lower_target", "field_line"],
         colors = colors,
-        save_name = save_name
+        save_name = save_name,
+        combine_regions = True,
     )
+
+    if save is True:
+        print(f"Saved plot to {os.path.abspath(save_name)}.png")
 
     tend = tm.time()
     print(f"Executed in {tend-tstart:.1f} seconds")

--- a/code_comparison/code_comparison.py
+++ b/code_comparison/code_comparison.py
@@ -315,9 +315,13 @@ class SOLPSdata:
         self.imp = pd.DataFrame()
         self.code = "SOLPS"
         
-    def read_from_case(self, casepath):
+    def read_from_case(self, casepath_or_case, path_b2fgmtry = None):
         
-        spc = SOLPScase(casepath)
+        if isinstance(casepath_or_case, str):
+            spc = SOLPScase(casepath_or_case, path_b2fgmtry = path_b2fgmtry)
+        else:
+            spc = casepath_or_case
+            
         spc.derive_data()
         data = spc.bal
         
@@ -334,7 +338,7 @@ class SOLPSdata:
             
             df = spc.get_1d_radial_data(list_params, region = name)
             df.index = df.pop("dist")
-            translate = dict(omp="omp", imp="imp", outer_lower_target="outer_lower_sol_extra", inner_lower_target="inner_lower_sol_extra")
+            translate = dict(omp="omp", imp="imp", outer_lower_target="outer_lower", inner_lower_target="inner_lower")
             
             regions[translate[name]] = df.copy()
 
@@ -517,8 +521,8 @@ class Hermesdata:
         
         self.regions["omp"] = get_1d_radial_data(ds, self.params, region = "outer_midplane")
         self.regions["imp"] = get_1d_radial_data(ds, self.params, region = "inner_midplane")
-        self.regions["outer_lower_sol"] = get_1d_radial_data(ds, self.params, region = "outer_lower_target")
-        self.regions["inner_lower_sol"] = get_1d_radial_data(ds, self.params, region = "inner_lower_target")
+        self.regions["outer_lower"] = get_1d_radial_data(ds, self.params, region = "outer_lower_target")
+        self.regions["inner_lower"] = get_1d_radial_data(ds, self.params, region = "inner_lower_target")
         
         self.regions["inner_fieldline_0.001"] = get_1d_poloidal_data(ds, self.params, region =  "inner_lower_sol", sepdist = 0.001)
         self.regions["outer_fieldline_0.001"] = get_1d_poloidal_data(ds, self.params, region =  "outer_lower_sol", sepdist = 0.001)
@@ -568,75 +572,75 @@ class Hermesdata:
             self.regions[region]["Tn"] = self.regions[region]["Ta"]
 
         
-    def get_radial_data(self, dataset):
-        """
-        Deprecated
-        """
-        self.dataset = dataset
+    # def get_radial_data(self, dataset):
+    #     """
+    #     Deprecated
+    #     """
+    #     self.dataset = dataset
 
-        x = []
-        for param in self.params:
+    #     x = []
+    #     for param in self.params:
             
-            ds = self.dataset   
-            dr = np.cumsum(ds["dr"].values.flatten())
-            m = self.ds.metadata
-            sep_idx = m["ixseps1"] - m["MXG"]
-            dist = dr - dr[sep_idx]
+    #         ds = self.dataset   
+    #         dr = np.cumsum(ds["dr"].values.flatten())
+    #         m = self.ds.metadata
+    #         sep_idx = m["ixseps1"] - m["MXG"]
+    #         dist = dr - dr[sep_idx]
             
-            df = pd.DataFrame(index = dist)
-            df.index.name = "pos"
-            if param in ds.data_vars:
-                df[param] = ds[param]
-            else:
-                df[param] = np.nan
-            x.append(df)
+    #         df = pd.DataFrame(index = dist)
+    #         df.index.name = "pos"
+    #         if param in ds.data_vars:
+    #             df[param] = ds[param]
+    #         else:
+    #             df[param] = np.nan
+    #         x.append(df)
             
-        df = pd.concat(x, axis = 1)
+    #     df = pd.concat(x, axis = 1)
 
-        # Normalise to separatrix
-        sep_R = df.index[self.ds.metadata["ixseps1"]- self.ds.metadata["MXG"]]
-        df.index -= sep_R
+    #     # Normalise to separatrix
+    #     sep_R = df.index[self.ds.metadata["ixseps1"]- self.ds.metadata["MXG"]]
+    #     df.index -= sep_R
         
-        return df
+    #     return df
     
-    def get_poloidal_data(self):
-        """
-        Deprecated
-        """
-        ds = self.ds
-        m = ds.metadata
+    # def get_poloidal_data(self):
+    #     """
+    #     Deprecated
+    #     """
+    #     ds = self.ds
+    #     m = ds.metadata
     
-        # Find the right poloidal flux tube by looking at the midplane
-        sep_dist = 0   # Hardcoded to separatrix
-        omp = ds.hermesm.select_region("outer_midplane_a")
+    #     # Find the right poloidal flux tube by looking at the midplane
+    #     sep_dist = 0   # Hardcoded to separatrix
+    #     omp = ds.hermesm.select_region("outer_midplane_a")
         
-        if ds.dims["x"] == ds.metadata["nxg"]:
-            adder = 0
-        else:
-            adder = 2
+    #     if ds.dims["x"] == ds.metadata["nxg"]:
+    #         adder = 0
+    #     else:
+    #         adder = 2
         
-        id_sep = m["ixseps1"] - adder
+    #     id_sep = m["ixseps1"] - adder
 
-        r = np.cumsum(omp["dr"].values)
-        r = r - r[id_sep]
+    #     r = np.cumsum(omp["dr"].values)
+    #     r = r - r[id_sep]
 
-        id_fl = np.argmin(np.abs(r - sep_dist))
-        id_omp = int((m["j2_2g"] - m["j1_2g"]) / 2) + m["j1_2g"]
-        fl = ds.isel(theta = slice(id_omp, -m["MYG"]), x = id_fl)
+    #     id_fl = np.argmin(np.abs(r - sep_dist))
+    #     id_omp = int((m["j2_2g"] - m["j1_2g"]) / 2) + m["j1_2g"]
+    #     fl = ds.isel(theta = slice(id_omp, -m["MYG"]), x = id_fl)
 
-        dist = np.cumsum(fl["dpol"].values)
-        dist -= dist[0]
+    #     dist = np.cumsum(fl["dpol"].values)
+    #     dist -= dist[0]
 
-        df = pd.DataFrame(index = dist)
+    #     df = pd.DataFrame(index = dist)
 
 
-        for param in self.params:
-            if param in fl.data_vars:
-                df[param] = fl[param].values
-            else:
-                df[param] = np.nan
+    #     for param in self.params:
+    #         if param in fl.data_vars:
+    #             df[param] = fl[param].values
+    #         else:
+    #             df[param] = np.nan
             
-        return df
+    #     return df
     
 
         

--- a/code_comparison/code_comparison.py
+++ b/code_comparison/code_comparison.py
@@ -106,15 +106,15 @@ class SOLEDGEdata:
         self.regions["outer_fieldline_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, d_from_sep=0.0009, parallel_length = True)
         
         
-        self.regions["inner_fieldline_0.001_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, region =  "outer_lower", d_from_sep = 0.001, parallel_length = True)
-        self.regions["outer_fieldline_0.001_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, region =  "outer_lower", d_from_sep = 0.001, parallel_length = True)
+        self.regions["inner_fieldline_0.001_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, region =  "outer_lower_sol", d_from_sep = 0.001, parallel_length = True)
+        self.regions["outer_fieldline_0.001_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, region =  "outer_lower_sol", d_from_sep = 0.001, parallel_length = True)
         
-        self.regions["outer_fieldline_0.003_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, region =  "outer_lower", d_from_sep = 0.003, parallel_length = True)
-        self.regions["outer_fieldline_0.015_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, region =  "outer_lower", d_from_sep = 0.015, parallel_length = True)
-        self.regions["outer_fieldline_0.030_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, region =  "outer_lower", d_from_sep = 0.030, parallel_length = True)
+        self.regions["outer_fieldline_0.003_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, region =  "outer_lower_sol", d_from_sep = 0.003, parallel_length = True)
+        self.regions["outer_fieldline_0.015_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, region =  "outer_lower_sol", d_from_sep = 0.015, parallel_length = True)
+        self.regions["outer_fieldline_0.030_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, region =  "outer_lower_sol", d_from_sep = 0.030, parallel_length = True)
         
-        self.regions["outer_upper_fieldline_0.001_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, region =  "outer_upper", d_from_sep = 0.001, parallel_length = True)
-        self.regions["outer_upper_fieldline_0.003_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, region =  "outer_upper", d_from_sep = 0.003, parallel_length = True)
+        self.regions["outer_upper_fieldline_0.001_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, region =  "outer_upper_sol", d_from_sep = 0.001, parallel_length = True)
+        self.regions["outer_upper_fieldline_0.003_parallel"] = self.case.get_1d_poloidal_data(params = self.case.params, region =  "outer_upper_sol", d_from_sep = 0.003, parallel_length = True)
         
         
         for region in self.regions.keys():
@@ -259,7 +259,7 @@ class SOLEDGEdata:
         strikepoints = dict()
         
         # Add neutrals
-        target = self.case.get_wall_data_on_target(self.case.get_wall_ntmpi(), "outer_lower")
+        target = self.case.get_wall_data_on_target(self.case.get_wall_ntmpi(), "outer_lower_sol")
         
         for col in target.columns:
             if col not in ["Ne", "Te"]:
@@ -271,7 +271,7 @@ class SOLEDGEdata:
                             })
         
         # Create copy of each df for each target with 0 being the strikepoint.
-        for i, target in enumerate(["inner_lower", "outer_lower", "outer_upper", "inner_upper"]):
+        for i, target in enumerate(["inner_lower_sol", "outer_lower_sol", "outer_upper_sol", "inner_upper_sol"]):
             strikepoints[target] = self.wallring.index[peaks[i]]
             df = self.wallring.copy()
             df.index -= strikepoints[target]
@@ -334,22 +334,22 @@ class SOLPSdata:
             
             df = spc.get_1d_radial_data(list_params, region = name)
             df.index = df.pop("dist")
-            translate = dict(omp="omp", imp="imp", outer_lower_target="outer_lower", inner_lower_target="inner_lower")
+            translate = dict(omp="omp", imp="imp", outer_lower_target="outer_lower_sol", inner_lower_target="inner_lower_sol")
             
             regions[translate[name]] = df.copy()
 
             
-        regions["inner_fieldline_0.001"] = spc.get_1d_poloidal_data(list_params, region =  "inner_lower", sepdist = 0.001)
-        regions["outer_fieldline"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower", sepdist = 0.001)
-        regions["outer_fieldline_0.001"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower", sepdist = 0.001)
-        regions["outer_fieldline_0.003"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower", sepdist = 0.003)
-        regions["outer_fieldline_0.015"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower", sepdist = 0.015)
-        regions["outer_fieldline_0.030"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower", sepdist = 0.030)
+        regions["inner_fieldline_0.001"] = spc.get_1d_poloidal_data(list_params, region =  "inner_lower_sol", sepdist = 0.001)
+        regions["outer_fieldline"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol", sepdist = 0.001)
+        regions["outer_fieldline_0.001"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol", sepdist = 0.001)
+        regions["outer_fieldline_0.003"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol", sepdist = 0.003)
+        regions["outer_fieldline_0.015"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol", sepdist = 0.015)
+        regions["outer_fieldline_0.030"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol", sepdist = 0.030)
         
-        regions["outer_upper_fieldline_0.001"] = spc.get_1d_poloidal_data(list_params, region =  "outer_upper", sepdist = 0.001)
-        regions["outer_upper_fieldline_0.003"] = spc.get_1d_poloidal_data(list_params, region =  "outer_upper", sepdist = 0.003)
+        regions["outer_upper_fieldline_0.001"] = spc.get_1d_poloidal_data(list_params, region =  "outer_upper_sol", sepdist = 0.001)
+        regions["outer_upper_fieldline_0.003"] = spc.get_1d_poloidal_data(list_params, region =  "outer_upper_sol", sepdist = 0.003)
         
-        regions["inner_fieldline"] = spc.get_1d_poloidal_data(list_params, region =  "inner_lower", sepdist = 0.0014)
+        regions["inner_fieldline"] = spc.get_1d_poloidal_data(list_params, region =  "inner_lower_sol", sepdist = 0.0014)
         
         for region in list(regions.keys()):
             if "fieldline" in region:
@@ -366,7 +366,7 @@ class SOLPSdata:
                     regions[region][param] = regions[region][param] * -1
                     
             ## ABSOLUTE MOMENTUM AT RADIAL SURFACES
-            if "outer_lower" in region or "inner_lower" in region:
+            if "outer_lower_sol" in region or "inner_lower_sol" in region:
                 for param in ["Vd+", "NVd+", "M"]:
                     regions[region][param] = np.abs(regions[region][param])
                     
@@ -403,7 +403,7 @@ class SOLPSdata:
                             self.params["omp"][param] = dfs[param]
                             
                         elif param.endswith("dr"):
-                            self.params["outer_lower"][param] = dfs[param]
+                            self.params["outer_lower_sol"][param] = dfs[param]
                             
                         elif param.endswith("di"):
                             self.params["imp"][param] = dfs[param]
@@ -429,7 +429,7 @@ class SOLPSdata:
                     self.params["omp"][param] = self.file[param]
                     
                 elif param.endswith("dr"):
-                    self.params["outer_lower"][param] = self.file[param]
+                    self.params["outer_lower_sol"][param] = self.file[param]
                     
                 elif param.endswith("di"):
                     self.params["imp"][param] = self.file[param]
@@ -443,7 +443,7 @@ class SOLPSdata:
         self.regions = dict()
         self.regions["omp"] = pd.concat(self.params["omp"].values(), axis = 1)
         self.regions["imp"] = pd.concat(self.params["imp"].values(), axis = 1)
-        self.regions["outer_lower"] = pd.concat(self.params["outer_lower"].values(), axis = 1)
+        self.regions["outer_lower_sol"] = pd.concat(self.params["outer_lower_sol"].values(), axis = 1)
         
 
     def derive_variables(self):
@@ -469,7 +469,7 @@ def parse_solps(param, loc):
     loc_key = {
         "omp" : "da",
         "imp" : "di",
-        "outer_lower" : "dr",
+        "outer_lower_sol" : "dr",
     }
     
     param_key = {
@@ -510,24 +510,24 @@ class Hermesdata:
         ## OLD
         # self.regions["omp"] = self.get_radial_data(ds.hermesm.select_region("outer_midplane_a").isel(x = slice(2,-2)))
         # self.regions["imp"] = self.get_radial_data(ds.hermesm.select_region("inner_midplane_a").isel(x = slice(2,-2)))
-        # self.regions["outer_lower"] = self.get_radial_data(ds.hermesm.select_region("outer_lower_target"))
-        # self.regions["outer_upper"] = self.get_radial_data(ds.hermesm.select_region("outer_upper_target"))
-        # self.regions["inner_lower"] = self.get_radial_data(ds.hermesm.select_region("inner_lower_target"))
+        # self.regions["outer_lower_sol"] = self.get_radial_data(ds.hermesm.select_region("outer_lower_target"))
+        # self.regions["outer_upper_sol"] = self.get_radial_data(ds.hermesm.select_region("outer_upper_target"))
+        # self.regions["inner_lower_sol"] = self.get_radial_data(ds.hermesm.select_region("inner_lower_target"))
         # self.regions["outer_fieldline"] = self.get_poloidal_data()
         
         self.regions["omp"] = get_1d_radial_data(ds, self.params, region = "outer_midplane")
         self.regions["imp"] = get_1d_radial_data(ds, self.params, region = "inner_midplane")
-        self.regions["outer_lower"] = get_1d_radial_data(ds, self.params, region = "outer_lower_target")
-        self.regions["inner_lower"] = get_1d_radial_data(ds, self.params, region = "inner_lower_target")
+        self.regions["outer_lower_sol"] = get_1d_radial_data(ds, self.params, region = "outer_lower_target")
+        self.regions["inner_lower_sol"] = get_1d_radial_data(ds, self.params, region = "inner_lower_target")
         
-        self.regions["inner_fieldline_0.001"] = get_1d_poloidal_data(ds, self.params, region =  "inner_lower", sepdist = 0.001)
-        self.regions["outer_fieldline_0.001"] = get_1d_poloidal_data(ds, self.params, region =  "outer_lower", sepdist = 0.001)
-        self.regions["outer_fieldline_0.003"] = get_1d_poloidal_data(ds, self.params, region =  "outer_lower", sepdist = 0.003)
-        self.regions["outer_fieldline_0.015"] = get_1d_poloidal_data(ds, self.params, region =  "outer_lower", sepdist = 0.015)
-        self.regions["outer_fieldline_0.030"] = get_1d_poloidal_data(ds, self.params, region =  "outer_lower", sepdist = 0.030)
+        self.regions["inner_fieldline_0.001"] = get_1d_poloidal_data(ds, self.params, region =  "inner_lower_sol", sepdist = 0.001)
+        self.regions["outer_fieldline_0.001"] = get_1d_poloidal_data(ds, self.params, region =  "outer_lower_sol", sepdist = 0.001)
+        self.regions["outer_fieldline_0.003"] = get_1d_poloidal_data(ds, self.params, region =  "outer_lower_sol", sepdist = 0.003)
+        self.regions["outer_fieldline_0.015"] = get_1d_poloidal_data(ds, self.params, region =  "outer_lower_sol", sepdist = 0.015)
+        self.regions["outer_fieldline_0.030"] = get_1d_poloidal_data(ds, self.params, region =  "outer_lower_sol", sepdist = 0.030)
         
-        self.regions["outer_upper_fieldline_0.001"] = get_1d_poloidal_data(ds, self.params, region =  "outer_upper", sepdist = 0.001)
-        self.regions["outer_upper_fieldline_0.003"] = get_1d_poloidal_data(ds, self.params, region =  "outer_upper", sepdist = 0.003)
+        self.regions["outer_upper_fieldline_0.001"] = get_1d_poloidal_data(ds, self.params, region =  "outer_upper_sol", sepdist = 0.001)
+        self.regions["outer_upper_fieldline_0.003"] = get_1d_poloidal_data(ds, self.params, region =  "outer_upper_sol", sepdist = 0.003)
         
         regions = list(self.regions.keys())
         for region in regions:
@@ -649,7 +649,7 @@ def lineplot_compare(
     mode = "log",
     colors = ["black", "red", "black", "red", "navy", "limegreen", "firebrick",  "limegreen", "magenta","cyan", "navy"],
     params = ["Td+", "Te", "Ta", "Ne", "Nd"],
-    regions = ["imp", "omp", "outer_lower", "outer_fieldline_parallel"],
+    regions = ["imp", "omp", "outer_lower_sol", "outer_fieldline_parallel"],
     ylims = (None,None),
     dpi = 120,
     lw = 1.5,
@@ -678,8 +678,8 @@ def lineplot_compare(
         "Td+": "log", "Te": "log", "Ta" : "log", "Tm" : "log",
         "Ne": "log", "Nd": "log", "Na" : "log", "Nm": "log", 
         "Pe":"log", "Pd+":"log", "NVd+":"log", "Vd+": "log", "M": "linear"},
-    "outer_lower" : {"Td+": "linear", "Te": "linear", "Td":"linear","Ta":"linear", "Ne": "linear", "Nd": "log"},
-    "outer_upper" : {"Td+": "linear", "Te": "linear", "Td":"linear","Ta":"linear", "Ne": "linear", "Nd": "log"},
+    "outer_lower_sol" : {"Td+": "linear", "Te": "linear", "Td":"linear","Ta":"linear", "Ne": "linear", "Nd": "log"},
+    "outer_upper_sol" : {"Td+": "linear", "Te": "linear", "Td":"linear","Ta":"linear", "Ne": "linear", "Nd": "log"},
     "outer_fieldline" : {"Td+": "linear", "Te": "linear", "Td":"linear","Ta":"linear", "Ne": "log", "Nd": "log"},
     "outer_fieldline_parallel" : {
         "Td+": "linear", "Te": "linear", "Td":"linear","Ta":"linear", "Tn":"linear","Tm":"linear",
@@ -687,15 +687,16 @@ def lineplot_compare(
         "Pe": "linear", "Pd+": "linear", "Pa": "log", "Pn":"log", "Pm":"log",
         "M": "linear", "NVd+": "linear", "Vd+": "linear"},
     }
-    set_yscales["inner_lower"] = set_yscales["outer_lower"]
-    set_yscales["inner_upper"] = set_yscales["outer_upper"]
+    set_yscales["inner_lower_sol"] = set_yscales["outer_lower_sol"]
+    set_yscales["inner_upper_sol"] = set_yscales["outer_upper_sol"]
     
     region_extents = {
         "omp" : (-0.06, 0.06),
         "imp" : (-0.10, 0.06),
-        "outer_lower" : (-0.018, 0.058),
-        "outer_upper" : (-0.02, 0.05),
-        "inner_lower" : (-0.04, 0.09),
+        "outer_lower_sol" : (-0.018, 0.058),
+        "outer_upper_sol" : (-0.02, 0.05),
+        "inner_lower_sol" : (-0.04, 0.09),
+        "inner_upper_sol" : (-0.04, 0.09),
         "outer_fieldline" : (0, 2),
         "outer_fieldline_parallel" : (0, 7),
         "inner_fieldline_parallel" : (0, 7)
@@ -873,9 +874,9 @@ def lineplot_compare(
                     axes[i].set_xlim(-0.06*xmult, 0.05*xmult)
                 elif region == "imp":
                     axes[i].set_xlim(-0.11*xmult, 0.09*xmult)
-                elif region == "outer_lower":
+                elif region == "outer_lower_sol":
                     axes[i].set_xlim(-0.03*xmult, 0.065*xmult )
-                elif region == "inner_lower":
+                elif region == "inner_lower_sol":
                     axes[i].set_xlim(-0.06*xmult, 0.10*xmult )
             
             axes[i].grid(which="both", color = "k", alpha = 0.1, lw = 0.5)
@@ -981,7 +982,7 @@ def plot_by_region(
             r"Hermes-3: max_mfp=1, cond_alpha=0.25" : dict(name='1e19', color = "teal"),
 
         },
-        regions = ["omp", "outer_fieldline_0.001_parallel", "outer_lower"],
+        regions = ["omp", "outer_fieldline_0.001_parallel", "outer_lower_sol"],
         params = ["Ne", "Te", "Td+", "NVd+", "Vd+", "M"],
         data_dicts = {"SOLPS":sp, "SOLEDGE2D":sl, "Hermes-3":hr},
         dpi = 100,

--- a/code_comparison/code_comparison.py
+++ b/code_comparison/code_comparison.py
@@ -624,7 +624,7 @@ class Hermesdata:
         id_omp = int((m["j2_2g"] - m["j1_2g"]) / 2) + m["j1_2g"]
         fl = ds.isel(theta = slice(id_omp, -m["MYG"]), x = id_fl)
 
-        dist = np.cumsum(fl["dl"].values)
+        dist = np.cumsum(fl["dpol"].values)
         dist -= dist[0]
 
         df = pd.DataFrame(index = dist)

--- a/code_comparison/code_comparison.py
+++ b/code_comparison/code_comparison.py
@@ -334,22 +334,22 @@ class SOLPSdata:
             
             df = spc.get_1d_radial_data(list_params, region = name)
             df.index = df.pop("dist")
-            translate = dict(omp="omp", imp="imp", outer_lower_target="outer_lower_sol", inner_lower_target="inner_lower_sol")
+            translate = dict(omp="omp", imp="imp", outer_lower_target="outer_lower_sol_extra", inner_lower_target="inner_lower_sol_extra")
             
             regions[translate[name]] = df.copy()
 
             
-        regions["inner_fieldline_0.001"] = spc.get_1d_poloidal_data(list_params, region =  "inner_lower_sol", sepdist = 0.001)
-        regions["outer_fieldline"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol", sepdist = 0.001)
-        regions["outer_fieldline_0.001"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol", sepdist = 0.001)
-        regions["outer_fieldline_0.003"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol", sepdist = 0.003)
-        regions["outer_fieldline_0.015"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol", sepdist = 0.015)
-        regions["outer_fieldline_0.030"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol", sepdist = 0.030)
+        regions["inner_fieldline_0.001"] = spc.get_1d_poloidal_data(list_params, region =  "inner_lower_sol_extra", sepdist = 0.001)
+        regions["outer_fieldline"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol_extra", sepdist = 0.001)
+        regions["outer_fieldline_0.001"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol_extra", sepdist = 0.001)
+        regions["outer_fieldline_0.003"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol_extra", sepdist = 0.003)
+        regions["outer_fieldline_0.015"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol_extra", sepdist = 0.015)
+        regions["outer_fieldline_0.030"] = spc.get_1d_poloidal_data(list_params, region =  "outer_lower_sol_extra", sepdist = 0.030)
         
-        regions["outer_upper_fieldline_0.001"] = spc.get_1d_poloidal_data(list_params, region =  "outer_upper_sol", sepdist = 0.001)
-        regions["outer_upper_fieldline_0.003"] = spc.get_1d_poloidal_data(list_params, region =  "outer_upper_sol", sepdist = 0.003)
+        regions["outer_upper_fieldline_0.001"] = spc.get_1d_poloidal_data(list_params, region =  "outer_upper_sol_extra", sepdist = 0.001)
+        regions["outer_upper_fieldline_0.003"] = spc.get_1d_poloidal_data(list_params, region =  "outer_upper_sol_extra", sepdist = 0.003)
         
-        regions["inner_fieldline"] = spc.get_1d_poloidal_data(list_params, region =  "inner_lower_sol", sepdist = 0.0014)
+        regions["inner_fieldline"] = spc.get_1d_poloidal_data(list_params, region =  "inner_lower_sol_extra", sepdist = 0.0014)
         
         for region in list(regions.keys()):
             if "fieldline" in region:

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -122,25 +122,9 @@ class interpolateSOLPStoHermes:
 
         print("\n\n CHECK GUARDS \n\n")
 
-    def interpolate_sol(self, param, regions, plot_lines=False, plot_interp_debug=False):
-        return self.interpolate(
-            param,
-            regions,
-            plot_lines=plot_lines,
-            plot_interp_debug=plot_interp_debug,
-        )
-    
-    def interpolate_core_pfr(self, param, regions, plot_lines=False, plot_interp_debug=False):
-        return self.interpolate(
-            param,
-            regions,
-            plot_lines=plot_lines,
-            plot_interp_debug=plot_interp_debug,
-        )
-
     def interpolate(self, param, regions, plot_lines=False, plot_interp_debug=False):
         ds = self.ds
-
+        self.plot_lines = plot_lines
 
         if plot_lines:
             _, plot_line_ax = plt.subplots(figsize=(10, 20), dpi=100)
@@ -150,7 +134,6 @@ class interpolateSOLPStoHermes:
             )
 
             self.plot_line_ax = plot_line_ax
-            self.plot_lines = True
 
             self.solps.plot_2d("Ne", ax =plot_line_ax, grid_only = True, linecolor = "red")
             plot_line_ax.set_xlim(*self.polygon_xlim)

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -14,28 +14,28 @@ class interpolateSOLPStoHermes:
         self.solps = solps
 
         self.region_settings = {
-            "inner_lower_upstream_extra": dict(
+            "inner_lower_upstream": dict(
                 radial_start_region="imp",
                 radial_subset="sol",
-                interpolate_midplane=True,
+                interpolate_midplane=False,
                 flip=True,
             ),
-            "inner_upper_upstream_extra": dict(
+            "inner_upper_upstream": dict(
                 radial_start_region="imp",
                 radial_subset="sol",
-                interpolate_midplane=True,
+                interpolate_midplane=False,
                 flip=False,
             ),
-            "outer_lower_upstream_extra": dict(
+            "outer_lower_upstream": dict(
                 radial_start_region="omp",
                 radial_subset="sol",
-                interpolate_midplane=True,
+                interpolate_midplane=False,
                 flip=False,
             ),
-            "outer_upper_upstream_extra": dict(
+            "outer_upper_upstream": dict(
                 radial_start_region="omp",
                 radial_subset="sol",
-                interpolate_midplane=True,
+                interpolate_midplane=False,
                 flip=True,
             ),
             "inner_lower_divertor": dict(
@@ -210,9 +210,10 @@ class interpolateSOLPStoHermes:
         radial = get_1d_radial_data(
             self.ds,
             params=["R", "Z"],
-            guards=True,
+            guards=False,
             region=spec["radial_start_region"],
         )
+
         radial_subset = radial[radial["region"] == spec["radial_subset"]]
 
         for radial_index in radial_subset.index.values:
@@ -223,26 +224,24 @@ class interpolateSOLPStoHermes:
     def _get_field_lines(self, region, spec, params, sepadd, sepdist):
         interpolate_midplane = spec["interpolate_midplane"]
 
-        print(region, sepadd, sepdist, interpolate_midplane)
-
-        # flh = get_1d_poloidal_data(
-        #     self.ds,
-        #     params=params + ["theta_idx"],
-        #     region=region,
-        #     sepadd=sepadd,
-        #     radial_start_region=spec["radial_start_region"],
-        #     interpolate_midplane=interpolate_midplane,
-        #     debug = True
-        # )
+        flh = get_1d_poloidal_data(
+            self.ds,
+            params=params + ["theta_idx"],
+            region=region,
+            sepadd=sepadd,
+            radial_start_region=spec["radial_start_region"],
+            interpolate_midplane=interpolate_midplane,
+            debug = False
+        )
         fls = self.solps.get_1d_poloidal_data(
             params=params,
             region=region,
             sepdist=sepdist,
             interpolate_midplane=interpolate_midplane,
             radial_start_region=spec["radial_start_region"],
-            debug = True
+            debug = False
         )
-        raise SystemExit
+        # raise SystemExit
 
         return flh, fls
 

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -159,10 +159,12 @@ class interpolateSOLPStoHermes:
             spec = self._get_region_settings(region)
             print(region, "\n")
 
+            if plot_line_ax is not None:
+                self._plot_invalid_rings(region, spec, plot_line_ax)
+
             for radial_index, sepadd, sepdist in self._iter_region_rings(spec):
                 print(f"{radial_index}/{sepadd}/{sepdist:4f}, ", end="")
 
-                # try:
                 flh, fls = self._get_field_lines(region, spec, params, sepadd, sepdist)
 
                 poloidal_indices, param_interp = self._get_interpolated(
@@ -175,11 +177,6 @@ class interpolateSOLPStoHermes:
                     plot_line_ax=plot_line_ax,
                 )
                 param_values[radial_index, poloidal_indices] = param_interp
-
-                # except Exception as e:
-                #     print(
-                #         f"\nError interpolating {param} for region {region}, sepadd {sepadd}: {e}"
-                #     )
 
             print("")
 
@@ -205,20 +202,76 @@ class interpolateSOLPStoHermes:
 
         return expanded
 
-    def _iter_region_rings(self, spec):
-        m = self.ds.metadata
-        radial = get_1d_radial_data(
+    def _get_region_ring_sets(self, spec):
+        hermes_radial_slice = get_1d_radial_data(
             self.ds,
             params=["R", "Z"],
             guards=False,
             region=spec["radial_start_region"],
         )
 
-        radial_subset = radial[radial["region"] == spec["radial_subset"]]
+        solps_radial_slice = self.solps.get_1d_radial_data(
+            ["R", "Z"],
+            guards=False,
+            region=spec["radial_start_region"],
+        )
 
-        for radial_index in radial_subset.index.values:
+        if spec["radial_subset"] == "sol":
+            hermes_candidate_rings = hermes_radial_slice[hermes_radial_slice["Srad"] > 0]
+            solps_available_rings = solps_radial_slice[solps_radial_slice["dist"] > 0]
+        elif spec["radial_subset"] == "core":
+            hermes_candidate_rings = hermes_radial_slice[hermes_radial_slice["Srad"] < 0]
+            solps_available_rings = solps_radial_slice[solps_radial_slice["dist"] < 0]
+        else:
+            raise ValueError(f"Unsupported radial subset {spec['radial_subset']}")
+
+        solps_min_sepdist = solps_available_rings["dist"].min()
+        solps_max_sepdist = solps_available_rings["dist"].max()
+
+        valid_hermes_rings = hermes_candidate_rings[
+            hermes_candidate_rings["Srad"].between(
+                solps_min_sepdist,
+                solps_max_sepdist,
+            )
+        ]
+        invalid_hermes_rings = hermes_candidate_rings[
+            ~hermes_candidate_rings.index.isin(valid_hermes_rings.index)
+        ]
+
+        return valid_hermes_rings, invalid_hermes_rings
+
+    def _plot_invalid_rings(self, region, spec, plot_line_ax):
+        m = self.ds.metadata
+        _, invalid_hermes_rings = self._get_region_ring_sets(spec)
+
+        for radial_index in invalid_hermes_rings.index.values:
             sepadd = radial_index - m["ixseps1"]
-            sepdist = radial_subset.loc[radial_index, "Srad"]
+            invalid_field_line = get_1d_poloidal_data(
+                self.ds,
+                params=["R", "Z", "theta_idx"],
+                region=region,
+                sepadd=sepadd,
+                radial_start_region=spec["radial_start_region"],
+                interpolate_midplane=spec["interpolate_midplane"],
+                debug=False,
+            )
+            plot_line_ax.plot(
+                invalid_field_line["R"],
+                invalid_field_line["Z"],
+                lw=2,
+                marker="o",
+                ms=6,
+                c="yellow",
+                markerfacecolor = "black"
+            )
+
+    def _iter_region_rings(self, spec):
+        m = self.ds.metadata
+        valid_hermes_rings, _ = self._get_region_ring_sets(spec)
+
+        for radial_index in valid_hermes_rings.index.values:
+            sepadd = radial_index - m["ixseps1"]
+            sepdist = valid_hermes_rings.loc[radial_index, "Srad"]
             yield radial_index, sepadd, sepdist
 
     def _get_field_lines(self, region, spec, params, sepadd, sepdist):

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -14,71 +14,95 @@ class interpolateSOLPStoHermes:
         self.solps = solps
 
         self.region_settings = {
-            "inner_lower_sol": dict(
+            "inner_lower_upstream_extra": dict(
                 radial_start_region="imp",
                 radial_subset="sol",
-                segments=("divertor", "sol"),
                 interpolate_midplane=True,
+                flip=True,
             ),
-            "inner_upper_sol": dict(
+            "inner_upper_upstream_extra": dict(
                 radial_start_region="imp",
                 radial_subset="sol",
-                segments=("divertor", "sol"),
                 interpolate_midplane=True,
+                flip=False,
             ),
-            "outer_lower_sol": dict(
+            "outer_lower_upstream_extra": dict(
                 radial_start_region="omp",
                 radial_subset="sol",
-                segments=("divertor", "sol"),
                 interpolate_midplane=True,
+                flip=False,
             ),
-            "outer_upper_sol": dict(
+            "outer_upper_upstream_extra": dict(
                 radial_start_region="omp",
                 radial_subset="sol",
-                segments=("divertor", "sol"),
                 interpolate_midplane=True,
+                flip=True,
+            ),
+            "inner_lower_divertor": dict(
+                radial_start_region="imp",
+                radial_subset="sol",
+                interpolate_midplane=False,
+                flip=True,
+            ),
+            "inner_upper_divertor": dict(
+                radial_start_region="imp",
+                radial_subset="sol",
+                interpolate_midplane=False,
+                flip=False,
+            ),
+            "outer_lower_divertor": dict(
+                radial_start_region="omp",
+                radial_subset="sol",
+                interpolate_midplane=False,
+                flip=False,
+            ),
+            "outer_upper_divertor": dict(
+                radial_start_region="omp",
+                radial_subset="sol",
+                interpolate_midplane=False,
+                flip=True,
             ),
             "core": dict(
                 radial_start_region="omp",
                 radial_subset="core",
-                segments=(None,),
                 interpolate_midplane=False,
+                flip=False,
             ),
             "lower_pfr": dict(
                 radial_start_region="outer_lower_target",
                 radial_subset="core",
-                segments=(None,),
                 interpolate_midplane=False,
+                flip=False,
             ),
             "upper_pfr": dict(
                 radial_start_region="outer_upper_target",
                 radial_subset="core",
-                segments=(None,),
                 interpolate_midplane=False,
+                flip=False,
             ),
             "inner_lower_pfr": dict(
                 radial_start_region="inner_lower_target",
                 radial_subset="core",
-                segments=(None,),
                 interpolate_midplane=False,
+                flip=True,
             ),
             "outer_lower_pfr": dict(
                 radial_start_region="outer_lower_target",
                 radial_subset="core",
-                segments=(None,),
                 interpolate_midplane=False,
+                flip=True,
             ),
             "inner_upper_pfr": dict(
                 radial_start_region="inner_upper_target",
                 radial_subset="core",
-                segments=(None,),
                 interpolate_midplane=False,
+                flip=True,
             ),
             "outer_upper_pfr": dict(
                 radial_start_region="outer_upper_target",
                 radial_subset="core",
-                segments=(None,),
                 interpolate_midplane=False,
+                flip=True,
             ),
         }
 
@@ -88,8 +112,11 @@ class interpolateSOLPStoHermes:
                 antialias=True,
                 separatrix=False,)
         
-        self.polygon_xlim = (0.1, 0.65)
-        self.polygon_ylim = (0.5, 0.9)
+        # self.polygon_xlim = (0.1, 0.65)
+        # self.polygon_ylim = (0.5, 0.9)
+
+        self.polygon_xlim = (None, None)
+        self.polygon_ylim = (None, None)
 
         print("\n\n CHECK GUARDS \n\n")
 
@@ -118,6 +145,8 @@ class interpolateSOLPStoHermes:
                 ax=plot_line_ax,
                 **self.polygon_settings,
             )
+
+            self.solps.plot_2d("Ne", ax =plot_line_ax, grid_only = True, linecolor = "red")
             plot_line_ax.set_xlim(*self.polygon_xlim)
             plot_line_ax.set_ylim(*self.polygon_ylim)
         else:
@@ -126,31 +155,31 @@ class interpolateSOLPStoHermes:
         params = ["R", "Z", param]
         param_values = np.zeros_like(ds[param].values)
 
-        for region in regions:
+        for region in self._expand_regions(regions):
             spec = self._get_region_settings(region)
             print(region, "\n")
 
             for radial_index, sepadd, sepdist in self._iter_region_rings(spec):
                 print(f"{radial_index}/{sepadd}/{sepdist:4f}, ", end="")
 
-                try:
-                    flh, fls = self._get_field_lines(region, spec, params, sepadd, sepdist)
+                # try:
+                flh, fls = self._get_field_lines(region, spec, params, sepadd, sepdist)
 
-                    for subregion in spec["segments"]:
-                        poloidal_indices, param_interp = self._get_interpolated(
-                            flh,
-                            fls,
-                            param,
-                            subregion=subregion,
-                            interp_debug=plot_interp_debug,
-                            plot_line_ax=plot_line_ax,
-                        )
-                        param_values[radial_index, poloidal_indices] = param_interp
+                poloidal_indices, param_interp = self._get_interpolated(
+                    flh,
+                    fls,
+                    param,
+                    region=region,
+                    flip=spec["flip"],
+                    interp_debug=plot_interp_debug,
+                    plot_line_ax=plot_line_ax,
+                )
+                param_values[radial_index, poloidal_indices] = param_interp
 
-                except Exception as e:
-                    print(
-                        f"\nError interpolating {param} for region {region}, sepadd {sepadd}: {e}"
-                    )
+                # except Exception as e:
+                #     print(
+                #         f"\nError interpolating {param} for region {region}, sepadd {sepadd}: {e}"
+                #     )
 
             print("")
 
@@ -163,6 +192,18 @@ class interpolateSOLPStoHermes:
             raise ValueError(f"Invalid region {region}")
 
         return self.region_settings[region]
+
+    def _expand_regions(self, regions):
+        expanded = []
+
+        for region in regions:
+            if region.endswith("_sol"):
+                base = region[:-4]
+                expanded.extend([f"{base}_upstream", f"{base}_divertor"])
+            else:
+                expanded.append(region)
+
+        return expanded
 
     def _iter_region_rings(self, spec):
         m = self.ds.metadata
@@ -182,20 +223,26 @@ class interpolateSOLPStoHermes:
     def _get_field_lines(self, region, spec, params, sepadd, sepdist):
         interpolate_midplane = spec["interpolate_midplane"]
 
-        flh = get_1d_poloidal_data(
-            self.ds,
-            params=params + ["theta_idx"],
-            region=region,
-            sepadd=sepadd,
-            interpolate_midplane=interpolate_midplane,
-        )
+        print(region, sepadd, sepdist, interpolate_midplane)
+
+        # flh = get_1d_poloidal_data(
+        #     self.ds,
+        #     params=params + ["theta_idx"],
+        #     region=region,
+        #     sepadd=sepadd,
+        #     radial_start_region=spec["radial_start_region"],
+        #     interpolate_midplane=interpolate_midplane,
+        #     debug = True
+        # )
         fls = self.solps.get_1d_poloidal_data(
             params=params,
             region=region,
             sepdist=sepdist,
             interpolate_midplane=interpolate_midplane,
             radial_start_region=spec["radial_start_region"],
+            debug = True
         )
+        raise SystemExit
 
         return flh, fls
 
@@ -213,7 +260,7 @@ class interpolateSOLPStoHermes:
         )
 
     def _get_interpolated(
-        self, flh, fls, param, subregion=None, interp_debug=False, plot_line_ax=None
+        self, flh, fls, param, region, flip=False, interp_debug=False, plot_line_ax=None
     ):
         """
         Interpolates a specified SOLPS parameter onto the Hermes-3 grid by performing
@@ -248,38 +295,26 @@ class interpolateSOLPStoHermes:
         represents a midplane cell edge.
         """
 
-        # Work on copies so the caller's DataFrames are not mutated between subregion calls
+        # Work on copies so the caller's DataFrames are not mutated between calls.
         flh = flh.copy()
         fls = fls.copy()
 
-        def flip(df):
+        
+
+        def flip_field_line(df):
             df["Spol"] = df["Spol"].iloc[-1] - df["Spol"]
             df["Spar"] = df["Spar"].iloc[-1] - df["Spar"]
-            df = df.iloc[::-1].reset_index(drop=True)
-            return df
+            return df.iloc[::-1].reset_index(drop=True)
 
-        if subregion == "divertor":
-            # Flip the field line to start at the target and
-            # interpolate up to the X-point
-
-            flh = flh[flh["region"] == "divertor"]
-            fls = fls[fls["region"] == "divertor"]
-
-            # Now target first
-            flh = flip(flh)
-            fls = flip(fls)
+        if flip:
+            flh = flip_field_line(flh)
+            fls = flip_field_line(fls)
 
 
-        elif subregion == "sol":
-            # Do not flip, interpolate from midplane to X-point
+        if len(flh) < 2 or len(fls) < 2:
+            raise ValueError(f"Not enough points to interpolate {region}")
 
-            # Remove first point, it's at the midplane cell edge
-            flh = flh.loc[1:, :]
-            fls = fls.loc[1:, :]
-
-            flh = flh[flh["region"] == "upstream"]
-            fls = fls[fls["region"] == "upstream"]
-
+        
         out = self._interpolate_values(fls["Spol"], fls[param], flh["Spol"])
 
         if interp_debug:
@@ -289,11 +324,12 @@ class interpolateSOLPStoHermes:
             ax.plot(flh["Spol"], out, label="Interpolated", marker="o")
             ax.legend()
 
-            if subregion == "sol":
+            if "upstream" in region:
                 ax.set_xlabel("Poloidal distance from midplane")
-            elif subregion == "divertor":
-                ax.set_xlabel("Poloidal distance from target")
-            # ax.set_xlim(0.8, None)
+            elif "divertor" in region:
+                ax.set_xlabel("Poloidal distance from X-point")
+            else:
+                ax.set_xlabel("Poloidal distance")
 
         if plot_line_ax:
             plot_line_ax.plot(flh["R"], flh["Z"], lw=1)

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -446,12 +446,12 @@ class interpolateSOLPStoHermes:
 
             hermes = get_1d_poloidal_data(ds_interp, params = [param], sepdist = sepdist, region = hermes_region, guards = False)
             hermes_interp = get_1d_poloidal_data(ds_interp, params = [f"{param}_interp"], sepdist = sepdist, region = hermes_region, guards = False)
-            solps = self.solps.get_1d_poloidal_data(params = [param], sepdist = sepdist, region = solps_region, guards = False, debug = True)
+            solps = self.solps.get_1d_poloidal_data(params = [param], sepdist = sepdist, region = solps_region, guards = False, debug = False)
 
 
-            ax.plot(solps["Spar"], solps[param], **style_SOLPS)
-            ax.plot(hermes["Spar"], hermes[param], **style_Hermes)
-            ax.plot(hermes_interp["Spar"], hermes_interp[f"{param}_interp"], **style_interp)
+            ax.plot(solps["Spol"], solps[param], **style_SOLPS)
+            ax.plot(hermes["Spol"], hermes[param], **style_Hermes)
+            ax.plot(hermes_interp["Spol"], hermes_interp[f"{param}_interp"], **style_interp)
             
             ax.set_title(f"{hermes_region}, hermes sepadd={sepadd}")
             ax.legend(fontsize = "x-small")

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -128,7 +128,7 @@ class interpolateSOLPStoHermes:
 
         if plot_lines:
             _, plot_line_ax = plt.subplots(figsize=(10, 20), dpi=100)
-            ds["Ne"].hermesm.clean_guards().bout.polygon(
+            ds["Ne"].hermes.clear_guards().bout.polygon(
                 ax=plot_line_ax,
                 **self.polygon_settings,
             )
@@ -197,7 +197,9 @@ class interpolateSOLPStoHermes:
             params=["R", "Z"],
             guards=False,
             region=spec["radial_start_region"],
+            debug = False
         )
+
 
         solps_radial_slice = self.solps.get_1d_radial_data(
             ["R", "Z"],
@@ -253,15 +255,24 @@ class interpolateSOLPStoHermes:
             )
 
     def _iter_region_rings(self, spec):
+        """
+        Iterable to return valid Hermes-3 poloidal rings and the corresponding
+        sepadd and sepdist. Valid means there is SOLPS data available at the desired
+        Hermes-3 sepdist.
+        """
         m = self.ds.metadata
         valid_hermes_rings, _ = self._get_region_ring_sets(spec)
 
         for radial_index in valid_hermes_rings.index.values:
+        # for radial_index in [20]:
             sepadd = radial_index - m["ixseps1"]
             sepdist = valid_hermes_rings.loc[radial_index, "Srad"]
             yield radial_index, sepadd, sepdist
 
     def _get_field_lines(self, region, spec, params, sepadd, sepdist):
+        """
+        Return field line dataframes for Hermes-3 and SOLPS
+        """
         interpolate_midplane = spec["interpolate_midplane"]
 
         flh = get_1d_poloidal_data(
@@ -274,6 +285,8 @@ class interpolateSOLPStoHermes:
             
             debug = False
         )
+
+
         fls = self.solps.get_1d_poloidal_data(
             params=params,
             region=region,
@@ -281,8 +294,11 @@ class interpolateSOLPStoHermes:
             interpolate_midplane=interpolate_midplane,
             radial_start_region=spec["radial_start_region"],
             extrapolate_radial = True,
-            debug = False
+            debug = False,
+            guards = False
         )
+
+
         # raise SystemExit
 
         return flh, fls
@@ -312,7 +328,8 @@ class interpolateSOLPStoHermes:
             y_source,
             kind="linear",
             bounds_error=False,
-            fill_value="extrapolate",
+            # fill_value="extrapolate",
+            fill_value=(y_source[0], y_source[-1]),
         )(
             x_target
         )
@@ -371,7 +388,6 @@ class interpolateSOLPStoHermes:
         if len(flh) < 2 or len(fls) < 2:
             raise ValueError(f"Not enough points to interpolate {region}")
 
-        
         out = self._interpolate_values(fls["Spol"], fls[param], flh["Spol"])
 
         if interp_debug:
@@ -421,43 +437,42 @@ class interpolateSOLPStoHermes:
             ax.set_title(hermes_region)
             ax.legend(fontsize = "x-small")
 
-        def plot_parallel_result(ax, param, sepdist, solps_region, hermes_region):
+        def plot_parallel_result(ax, param, sepadd, solps_region, hermes_region):
             
+            radial_region = "omp" if "outer" in hermes_region else "imp"
+            radial_slice = get_1d_radial_data(ds_interp, params = ["R", "Z"], region = radial_region, guards = False)
+            radial_sol = radial_slice[radial_slice["region"] == "sol"]
+            sepdist = radial_sol.iloc[sepadd]["Srad"]
+
             hermes = get_1d_poloidal_data(ds_interp, params = [param], sepdist = sepdist, region = hermes_region, guards = False)
             hermes_interp = get_1d_poloidal_data(ds_interp, params = [f"{param}_interp"], sepdist = sepdist, region = hermes_region, guards = False)
-            solps = self.solps.get_1d_poloidal_data(params = [param], sepdist = sepdist, region = solps_region, guards = False)
+            solps = self.solps.get_1d_poloidal_data(params = [param], sepdist = sepdist, region = solps_region, guards = False, debug = True)
 
 
             ax.plot(solps["Spar"], solps[param], **style_SOLPS)
             ax.plot(hermes["Spar"], hermes[param], **style_Hermes)
             ax.plot(hermes_interp["Spar"], hermes_interp[f"{param}_interp"], **style_interp)
             
-            ax.set_title(f"{hermes_region}, sepdist={sepdist}")
+            ax.set_title(f"{hermes_region}, hermes sepadd={sepadd}")
             ax.legend(fontsize = "x-small")
 
         num_cols = 6
         fig, axes = plt.subplots(3,num_cols, figsize=(num_cols*5,15))
 
-        plot_radial_result(axes[0,0], "Ne", "omp", "omp")
-        plot_radial_result(axes[0,1], "Ne", "imp", "imp")
-        plot_radial_result(axes[0,2], "Ne", "inner_lower_target", "inner_lower_target")
-        plot_radial_result(axes[0,3], "Ne", "inner_upper_target", "inner_upper_target")
-        plot_radial_result(axes[0,4], "Ne", "outer_lower_target", "outer_lower_target")
-        plot_radial_result(axes[0,5], "Ne", "outer_upper_target", "outer_upper_target")
+        plot_radial_result(axes[0,0], param, "omp", "omp")
+        plot_radial_result(axes[0,1], param, "imp", "imp")
+        plot_radial_result(axes[0,2], param, "inner_lower_target", "inner_lower_target")
+        plot_radial_result(axes[0,3], param, "inner_upper_target", "inner_upper_target")
+        plot_radial_result(axes[0,4], param, "outer_lower_target", "outer_lower_target")
+        plot_radial_result(axes[0,5], param, "outer_upper_target", "outer_upper_target")
 
         # These sepdist values are at Hermes-3 cell centres
-        plot_parallel_result(axes[1,2], "Ne", 0.000416, "inner_lower_sol", "inner_lower_sol")
-        plot_parallel_result(axes[1,3], "Ne", 0.000416, "inner_upper_sol", "inner_upper_sol")
-        plot_parallel_result(axes[1,4], "Ne", 0.000416, "outer_lower_sol", "outer_lower_sol")
-        plot_parallel_result(axes[1,5], "Ne", 0.000416, "outer_upper_sol", "outer_upper_sol")
+        plot_parallel_result(axes[1,2], param, 0, "inner_lower_sol_extra", "inner_lower_sol")
+        plot_parallel_result(axes[1,3], param, 0, "inner_upper_sol_extra", "inner_upper_sol")
+        plot_parallel_result(axes[1,4], param, 0, "outer_lower_sol_extra", "outer_lower_sol")
+        plot_parallel_result(axes[1,5], param, 0, "outer_upper_sol_extra", "outer_upper_sol")
 
-        plot_parallel_result(axes[2,2], "Ne", 0.014630, "inner_lower_sol", "inner_lower_sol")
-        plot_parallel_result(axes[2,3], "Ne", 0.014630, "inner_upper_sol", "inner_upper_sol")
-        plot_parallel_result(axes[2,4], "Ne", 0.014630, "outer_lower_sol", "outer_lower_sol")
-        plot_parallel_result(axes[2,5], "Ne", 0.014630, "outer_upper_sol", "outer_upper_sol")
-
-
-
-        # plot_parallel_result(axes[1,2], "Ne", 0.014630, "outer_lower_sol", "outer_lower_sol")
-        # plot_parallel_result(axes[1,3], "Ne", 0.000202, "inner_lower_sol", "inner_lower_sol")
-        # plot_parallel_result(axes[1,4], "Ne", 0.014630, "inner_lower_sol", "inner_lower_sol")
+        plot_parallel_result(axes[2,2], param, 4, "inner_lower_sol_extra", "inner_lower_sol")
+        plot_parallel_result(axes[2,3], param, 4, "inner_upper_sol_extra", "inner_upper_sol")
+        plot_parallel_result(axes[2,4], param, 4, "outer_lower_sol_extra", "outer_lower_sol")
+        plot_parallel_result(axes[2,5], param, 4, "outer_upper_sol_extra", "outer_upper_sol")

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -13,81 +13,144 @@ class interpolateSOLPStoHermes:
         self.ds = ds
         self.solps = solps
 
-    def interpolate(self, param, regions, plot_lines=False, plot_interp_debug=False):
-        m = self.ds.metadata
-        ds = self.ds
-        solps = self.solps
+        self.region_settings = {
+            "inner_lower_sol": dict(
+                radial_start_region="imp",
+                radial_subset="sol",
+                segments=("divertor", "sol"),
+                interpolate_midplane=True,
+            ),
+            "inner_upper_sol": dict(
+                radial_start_region="imp",
+                radial_subset="sol",
+                segments=("divertor", "sol"),
+                interpolate_midplane=True,
+            ),
+            "outer_lower_sol": dict(
+                radial_start_region="omp",
+                radial_subset="sol",
+                segments=("divertor", "sol"),
+                interpolate_midplane=True,
+            ),
+            "outer_upper_sol": dict(
+                radial_start_region="omp",
+                radial_subset="sol",
+                segments=("divertor", "sol"),
+                interpolate_midplane=True,
+            ),
+            "core": dict(
+                radial_start_region="omp",
+                radial_subset="core",
+                segments=(None,),
+                interpolate_midplane=False,
+            ),
+            "lower_pfr": dict(
+                radial_start_region="outer_lower_target",
+                radial_subset="core",
+                segments=(None,),
+                interpolate_midplane=False,
+            ),
+            "upper_pfr": dict(
+                radial_start_region="outer_upper_target",
+                radial_subset="core",
+                segments=(None,),
+                interpolate_midplane=False,
+            ),
+            "inner_lower_pfr": dict(
+                radial_start_region="inner_lower_target",
+                radial_subset="core",
+                segments=(None,),
+                interpolate_midplane=False,
+            ),
+            "outer_lower_pfr": dict(
+                radial_start_region="outer_lower_target",
+                radial_subset="core",
+                segments=(None,),
+                interpolate_midplane=False,
+            ),
+            "inner_upper_pfr": dict(
+                radial_start_region="inner_upper_target",
+                radial_subset="core",
+                segments=(None,),
+                interpolate_midplane=False,
+            ),
+            "outer_upper_pfr": dict(
+                radial_start_region="outer_upper_target",
+                radial_subset="core",
+                segments=(None,),
+                interpolate_midplane=False,
+            ),
+        }
 
-        if plot_lines:
-            fig, plot_line_ax = plt.subplots(figsize=(10, 20), dpi=100)
-            ds["Ne"].hermesm.clean_guards().bout.polygon(
-                ax=plot_line_ax,
-                grid_only=True,
+        self.polygon_settings = dict(grid_only=True,
                 linecolor="k",
                 linewidth=0.3,
                 antialias=True,
-                separatrix=False,
+                separatrix=False,)
+        
+        self.polygon_xlim = (0.1, 0.65)
+        self.polygon_ylim = (0.5, 0.9)
+
+        print("\n\n CHECK GUARDS \n\n")
+
+    def interpolate_sol(self, param, regions, plot_lines=False, plot_interp_debug=False):
+        return self.interpolate(
+            param,
+            regions,
+            plot_lines=plot_lines,
+            plot_interp_debug=plot_interp_debug,
+        )
+    
+    def interpolate_core_pfr(self, param, regions, plot_lines=False, plot_interp_debug=False):
+        return self.interpolate(
+            param,
+            regions,
+            plot_lines=plot_lines,
+            plot_interp_debug=plot_interp_debug,
+        )
+
+    def interpolate(self, param, regions, plot_lines=False, plot_interp_debug=False):
+        ds = self.ds
+
+        if plot_lines:
+            _, plot_line_ax = plt.subplots(figsize=(10, 20), dpi=100)
+            ds["Ne"].hermesm.clean_guards().bout.polygon(
+                ax=plot_line_ax,
+                **self.polygon_settings,
             )
-            plot_line_ax.set_xlim(0.1, 0.65)
-            # plot_line_ax.set_ylim(-0.9, -0.5)
-            plot_line_ax.set_ylim(0.5, 0.9)
-            plot_line_ax.set_title("Lines=hermes, points=solps")
+            plot_line_ax.set_xlim(*self.polygon_xlim)
+            plot_line_ax.set_ylim(*self.polygon_ylim)
+        else:
+            plot_line_ax = None
 
         params = ["R", "Z", param]
         param_values = np.zeros_like(ds[param].values)
 
         for region in regions:
+            spec = self._get_region_settings(region)
             print(region, "\n")
 
-            ## Get radial slice to determine sepdist for a given sepadd
-            if "inner" in region:
-                midplane_region = "imp"
-            elif "outer" in region:
-                midplane_region = "omp"
-            else:
-                raise ValueError(
-                    f"Invalid region {region}, must contain 'inner' or 'outer'"
-                )
+            for radial_index, sepadd, sepdist in self._iter_region_rings(spec):
+                print(f"{radial_index}/{sepadd}/{sepdist:4f}, ", end="")
 
-            # Origin radial slice to define sepdist
-            radial = get_1d_radial_data(
-                self.ds, params=["R", "Z"], guards=True, region=midplane_region
-            )
-            radial_sol = radial[radial["region"] == "sol"]
-            num_solrings = len(radial_sol) - 2
-
-            ## For each Hermes-3 SOL ring, find the corresponding interpolated SOLPS
-            ## SOL ring
-            for sepadd in range(num_solrings):
-
-                radial_index = sepadd + m["ixseps1"]
-                sepdist = radial_sol.loc[radial_index, "Srad"]
-                print(f"{sepadd}/{sepdist:4f}, ", end="")
-
-                # Fetch field lines once per SOL ring, shared across divertor/sol subregions
                 try:
-                    flh = get_1d_poloidal_data(
-                        ds, params=params + ["theta_idx"], region=region, sepadd=sepadd
-                    )
-                    fls = solps.get_1d_poloidal_data(
-                        params=params, region=region, sepdist=sepdist
-                    )
+                    flh, fls = self._get_field_lines(region, spec, params, sepadd, sepdist)
 
-                    for subregion in ["divertor", "sol"]:
+                    for subregion in spec["segments"]:
                         poloidal_indices, param_interp = self._get_interpolated(
                             flh,
                             fls,
                             param,
                             subregion=subregion,
                             interp_debug=plot_interp_debug,
-                            plot_line_ax=plot_line_ax if plot_lines else None,
+                            plot_line_ax=plot_line_ax,
                         )
-
                         param_values[radial_index, poloidal_indices] = param_interp
-                except Exception as e:
-                    print(f"\nError interpolating {param} for region {region}, sepadd {sepadd}: {e}")
-                    pass
 
+                except Exception as e:
+                    print(
+                        f"\nError interpolating {param} for region {region}, sepadd {sepadd}: {e}"
+                    )
 
             print("")
 
@@ -95,8 +158,62 @@ class interpolateSOLPStoHermes:
 
         return ds
 
+    def _get_region_settings(self, region):
+        if region not in self.region_settings:
+            raise ValueError(f"Invalid region {region}")
+
+        return self.region_settings[region]
+
+    def _iter_region_rings(self, spec):
+        m = self.ds.metadata
+        radial = get_1d_radial_data(
+            self.ds,
+            params=["R", "Z"],
+            guards=True,
+            region=spec["radial_start_region"],
+        )
+        radial_subset = radial[radial["region"] == spec["radial_subset"]]
+
+        for radial_index in radial_subset.index.values:
+            sepadd = radial_index - m["ixseps1"]
+            sepdist = radial_subset.loc[radial_index, "Srad"]
+            yield radial_index, sepadd, sepdist
+
+    def _get_field_lines(self, region, spec, params, sepadd, sepdist):
+        interpolate_midplane = spec["interpolate_midplane"]
+
+        flh = get_1d_poloidal_data(
+            self.ds,
+            params=params + ["theta_idx"],
+            region=region,
+            sepadd=sepadd,
+            interpolate_midplane=interpolate_midplane,
+        )
+        fls = self.solps.get_1d_poloidal_data(
+            params=params,
+            region=region,
+            sepdist=sepdist,
+            interpolate_midplane=interpolate_midplane,
+            radial_start_region=spec["radial_start_region"],
+        )
+
+        return flh, fls
+
+    def _interpolate_values(self, x_source, y_source, x_target):
+        x_source = np.asarray(x_source)
+        y_source = np.asarray(y_source)
+        x_target = np.asarray(x_target)
+
+        if len(x_source) < 2:
+            raise ValueError("Need at least two points for interpolation")
+
+        spline_order = min(3, len(x_source) - 1)
+        return scipy.interpolate.make_interp_spline(x_source, y_source, k=spline_order)(
+            x_target
+        )
+
     def _get_interpolated(
-        self, flh, fls, param, subregion, interp_debug=False, plot_line_ax=None
+        self, flh, fls, param, subregion=None, interp_debug=False, plot_line_ax=None
     ):
         """
         Interpolates a specified SOLPS parameter onto the Hermes-3 grid by performing
@@ -138,7 +255,7 @@ class interpolateSOLPStoHermes:
         def flip(df):
             df["Spol"] = df["Spol"].iloc[-1] - df["Spol"]
             df["Spar"] = df["Spar"].iloc[-1] - df["Spar"]
-            df = df.iloc[::-1]
+            df = df.iloc[::-1].reset_index(drop=True)
             return df
 
         if subregion == "divertor":
@@ -152,9 +269,6 @@ class interpolateSOLPStoHermes:
             flh = flip(flh)
             fls = flip(fls)
 
-            out = scipy.interpolate.make_interp_spline(fls["Spol"], fls[param])(
-                flh["Spol"]
-            )
 
         elif subregion == "sol":
             # Do not flip, interpolate from midplane to X-point
@@ -166,7 +280,7 @@ class interpolateSOLPStoHermes:
             flh = flh[flh["region"] == "upstream"]
             fls = fls[fls["region"] == "upstream"]
 
-            out = np.interp(flh["Spol"], fls["Spol"], fls[param])
+        out = self._interpolate_values(fls["Spol"], fls[param], flh["Spol"])
 
         if interp_debug:
             fig, ax = plt.subplots()
@@ -188,6 +302,8 @@ class interpolateSOLPStoHermes:
         poloidal_indices = flh["theta_idx"].values.astype(int)
 
         return poloidal_indices, out
+    
+
     
     def check_1d(self, ds_interp, param):
 

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -188,3 +188,50 @@ class interpolateSOLPStoHermes:
         poloidal_indices = flh["theta_idx"].values.astype(int)
 
         return poloidal_indices, out
+    
+    def check_1d(self, ds_interp, param):
+
+        lw = 1
+        style_SOLPS = dict(c="k", marker="o", linewidth = lw, label="SOLPS")
+        style_Hermes = dict(c="darkorange", marker="+", linewidth = lw, label="Hermes")
+        style_interp = dict(c="deeppink", marker="X", linewidth = lw, label="Hermes interpolated")
+
+        def plot_radial_result(ax, param, solps_region, hermes_region):
+
+            hermes = get_1d_radial_data(ds_interp, params = [param], region = hermes_region)
+            hermes_interp = get_1d_radial_data(ds_interp, params = [f"{param}_interp"], region = hermes_region)
+            solps = self.solps.get_1d_radial_data(params = [param], region = solps_region)
+
+            ax.plot(solps["dist"], solps[param], **style_SOLPS)
+            ax.plot(hermes["Srad"], hermes[param], **style_Hermes)
+            ax.plot(hermes_interp["Srad"], hermes_interp[f"{param}_interp"], **style_interp)
+            
+            ax.set_title(hermes_region)
+            ax.legend(fontsize = "x-small")
+
+        def plot_parallel_result(ax, param, sepdist, solps_region, hermes_region):
+            
+            hermes = get_1d_poloidal_data(ds_interp, params = [param], sepdist = sepdist, region = hermes_region)
+            hermes_interp = get_1d_poloidal_data(ds_interp, params = [f"{param}_interp"], sepdist = sepdist, region = hermes_region)
+            solps = self.solps.get_1d_poloidal_data(params = [param], sepdist = sepdist, region = solps_region)
+
+            ax.plot(solps["Spar"], solps[param], **style_SOLPS)
+            ax.plot(hermes["Spar"], hermes[param], **style_Hermes)
+            ax.plot(hermes_interp["Spar"], hermes_interp[f"{param}_interp"], **style_interp)
+            
+            ax.set_title(f"{hermes_region}, sepdist={sepdist}")
+            ax.legend(fontsize = "x-small")
+
+        num_plots = 5
+        fig, axes = plt.subplots(2,num_plots, figsize=(num_plots*5,10))
+
+        plot_radial_result(axes[0,0], "Ne", "omp", "omp")
+        plot_radial_result(axes[0,1], "Ne", "imp", "imp")
+        plot_radial_result(axes[0,2], "Ne", "inner_lower_target", "inner_lower_target")
+        plot_radial_result(axes[0,3], "Ne", "outer_lower_target", "outer_lower_target")
+
+        # These sepdist values are at Hermes-3 cell centres
+        plot_parallel_result(axes[1,0], "Ne", 0.000202, "outer_lower_sol", "outer_lower_sol")
+        plot_parallel_result(axes[1,1], "Ne", 0.014630, "outer_lower_sol", "outer_lower_sol")
+        plot_parallel_result(axes[1,2], "Ne", 0.000202, "inner_lower_sol", "inner_lower_sol")
+        plot_parallel_result(axes[1,3], "Ne", 0.014630, "inner_lower_sol", "inner_lower_sol")

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -50,13 +50,13 @@ class interpolateSOLPStoHermes:
                 radial_start_region="imp",
                 radial_subset="sol",
                 interpolate_midplane=False,
-                flip=False,
+                flip=True,
             ),
             "outer_lower_divertor": dict(
                 radial_start_region="omp",
                 radial_subset="sol",
                 interpolate_midplane=False,
-                flip=False,
+                flip=True,
             ),
             "outer_upper_divertor": dict(
                 radial_start_region="omp",

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -206,7 +206,7 @@ class interpolateSOLPStoHermes:
         )
 
     
-        if self.plot_lines:
+        if getattr(self, "plot_lines", False):
             self.plot_line_ax.plot(hermes_radial_slice["R"], hermes_radial_slice["Z"], lw=2, marker="o", c="cyan", ms=3)
 
         if spec["radial_subset"] == "sol":
@@ -218,18 +218,12 @@ class interpolateSOLPStoHermes:
         else:
             raise ValueError(f"Unsupported radial subset {spec['radial_subset']}")
 
-        solps_min_sepdist = solps_available_rings["dist"].min()
-        solps_max_sepdist = solps_available_rings["dist"].max()
-
-        valid_hermes_rings = hermes_candidate_rings[
-            hermes_candidate_rings["Srad"].between(
-                solps_min_sepdist,
-                solps_max_sepdist,
-            )
-        ]
-        invalid_hermes_rings = hermes_candidate_rings[
-            ~hermes_candidate_rings.index.isin(valid_hermes_rings.index)
-        ]
+        if len(solps_available_rings) == 0:
+            valid_hermes_rings = hermes_candidate_rings.iloc[0:0]
+            invalid_hermes_rings = hermes_candidate_rings
+        else:
+            valid_hermes_rings = hermes_candidate_rings
+            invalid_hermes_rings = hermes_candidate_rings.iloc[0:0]
 
         return valid_hermes_rings, invalid_hermes_rings
 
@@ -254,8 +248,8 @@ class interpolateSOLPStoHermes:
                 lw=2,
                 marker="o",
                 ms=6,
-                c="yellow",
-                markerfacecolor = "black"
+                c="red",
+                markerfacecolor="black",
             )
 
     def _iter_region_rings(self, spec):
@@ -354,9 +348,8 @@ class interpolateSOLPStoHermes:
                 1D array of interpolated parameter values on Hermes-3 grid coordinates.
         Notes
         -----
-        The function uses cubic spline interpolation (k=3) for divertor mode and linear
-        interpolation for SOL mode. The first point is removed in SOL mode as it
-        represents a midplane cell edge.
+        The function uses linear interpolation along the SOLPS field line onto the
+        Hermes-3 field line coordinates.
         """
 
         # Work on copies so the caller's DataFrames are not mutated between calls.
@@ -396,8 +389,7 @@ class interpolateSOLPStoHermes:
                 ax.set_xlabel("Poloidal distance")
 
         if plot_line_ax:
-            plot_line_ax.plot(flh["R"], flh["Z"], lw=1)
-            plot_line_ax.plot(fls["R"], fls["Z"], lw=0, marker="o", c="deeppink", ms=1)
+            plot_line_ax.plot(fls["R"], fls["Z"], marker="o", lw=2, ms = 3, c="deeppink")
 
         poloidal_indices = flh["theta_idx"].values.astype(int)
 

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -382,10 +382,10 @@ class interpolateSOLPStoHermes:
         out = self._interpolate_values(fls["Spol"], fls[param], flh["Spol"])
 
         if interp_debug:
-            ax = interp_debug_ax
+            fig, ax = plt.subplots()
             ax.plot(flh["Spol"], flh[param], label="Hermes", marker="o")
-            ax.plot(fls["Spol"], fls[param], label="SOLPS", marker="x")
-            ax.plot(flh["Spol"], out, label="Interpolated", marker="o")
+            ax.plot(fls["Spol"], fls[param], label="SOLPS", marker="x", c= "k", markeredgewidth = 10)
+            ax.plot(flh["Spol"], out, label="Interpolated",  c = "darkorange", marker="o")
             ax.legend()
 
             if "upstream" in region:

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -318,8 +318,25 @@ class interpolateSOLPStoHermes:
         if len(x_source) < 2:
             raise ValueError("Need at least two points for interpolation")
 
-        spline_order = min(3, len(x_source) - 1)
-        return scipy.interpolate.make_interp_spline(x_source, y_source, k=spline_order)(
+        x_min = x_source.min()
+        x_max = x_source.max()
+        below_source = x_target < x_min
+        above_source = x_target > x_max
+        num_extrapolated = np.count_nonzero(below_source | above_source)
+
+        if num_extrapolated > 0:
+            print(
+                "Extrapolating poloidal interpolation for "
+                f"{num_extrapolated} target points outside the source range "
+                f"[{x_min}, {x_max}]")
+
+        return scipy.interpolate.interp1d(
+            x_source,
+            y_source,
+            kind="linear",
+            bounds_error=False,
+            fill_value="extrapolate",
+        )(
             x_target
         )
 

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -431,9 +431,10 @@ class interpolateSOLPStoHermes:
 
         def plot_parallel_result(ax, param, sepdist, solps_region, hermes_region):
             
-            hermes = get_1d_poloidal_data(ds_interp, params = [param], sepdist = sepdist, region = hermes_region)
-            hermes_interp = get_1d_poloidal_data(ds_interp, params = [f"{param}_interp"], sepdist = sepdist, region = hermes_region)
-            solps = self.solps.get_1d_poloidal_data(params = [param], sepdist = sepdist, region = solps_region)
+            hermes = get_1d_poloidal_data(ds_interp, params = [param], sepdist = sepdist, region = hermes_region, guards = False)
+            hermes_interp = get_1d_poloidal_data(ds_interp, params = [f"{param}_interp"], sepdist = sepdist, region = hermes_region, guards = False)
+            solps = self.solps.get_1d_poloidal_data(params = [param], sepdist = sepdist, region = solps_region, guards = False)
+
 
             ax.plot(solps["Spar"], solps[param], **style_SOLPS)
             ax.plot(hermes["Spar"], hermes[param], **style_Hermes)
@@ -453,10 +454,10 @@ class interpolateSOLPStoHermes:
         plot_radial_result(axes[0,5], "Ne", "outer_upper_target", "outer_upper_target")
 
         # These sepdist values are at Hermes-3 cell centres
-        plot_parallel_result(axes[1,2], "Ne", 0.000202, "inner_lower_sol", "inner_lower_sol")
-        plot_parallel_result(axes[1,3], "Ne", 0.000202, "inner_upper_sol", "inner_upper_sol")
-        plot_parallel_result(axes[1,4], "Ne", 0.000202, "outer_lower_sol", "outer_lower_sol")
-        plot_parallel_result(axes[1,5], "Ne", 0.000202, "outer_upper_sol", "outer_upper_sol")
+        plot_parallel_result(axes[1,2], "Ne", 0.000416, "inner_lower_sol", "inner_lower_sol")
+        plot_parallel_result(axes[1,3], "Ne", 0.000416, "inner_upper_sol", "inner_upper_sol")
+        plot_parallel_result(axes[1,4], "Ne", 0.000416, "outer_lower_sol", "outer_lower_sol")
+        plot_parallel_result(axes[1,5], "Ne", 0.000416, "outer_upper_sol", "outer_upper_sol")
 
         plot_parallel_result(axes[2,2], "Ne", 0.014630, "inner_lower_sol", "inner_lower_sol")
         plot_parallel_result(axes[2,3], "Ne", 0.014630, "inner_upper_sol", "inner_upper_sol")

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -49,39 +49,45 @@ class interpolateSOLPStoHermes:
                     f"Invalid region {region}, must contain 'inner' or 'outer'"
                 )
 
-            # Get radial slice at target to get separatrix distances
+            # Origin radial slice to define sepdist
             radial = get_1d_radial_data(
                 self.ds, params=["R", "Z"], guards=True, region=midplane_region
             )
             radial_sol = radial[radial["region"] == "sol"]
             num_solrings = len(radial_sol) - 2
 
-            ## Get poloidal slices
+            ## For each Hermes-3 SOL ring, find the corresponding interpolated SOLPS
+            ## SOL ring
             for sepadd in range(num_solrings):
-                # for sepadd in [0]:
+
                 radial_index = sepadd + m["ixseps1"]
                 sepdist = radial_sol.loc[radial_index, "Srad"]
                 print(f"{sepadd}/{sepdist:4f}, ", end="")
 
                 # Fetch field lines once per SOL ring, shared across divertor/sol subregions
-                flh = get_1d_poloidal_data(
-                    ds, params=params + ["theta_idx"], region=region, sepadd=sepadd
-                )
-                fls = solps.get_1d_poloidal_data(
-                    params=params, region=region, sepdist=sepdist
-                )
-
-                for subregion in ["divertor", "sol"]:
-                    poloidal_indices, param_interp = self._get_interpolated(
-                        flh,
-                        fls,
-                        param,
-                        subregion=subregion,
-                        interp_debug=plot_interp_debug,
-                        plot_line_ax=plot_line_ax if plot_lines else None,
+                try:
+                    flh = get_1d_poloidal_data(
+                        ds, params=params + ["theta_idx"], region=region, sepadd=sepadd
+                    )
+                    fls = solps.get_1d_poloidal_data(
+                        params=params, region=region, sepdist=sepdist
                     )
 
-                    param_values[radial_index, poloidal_indices] = param_interp
+                    for subregion in ["divertor", "sol"]:
+                        poloidal_indices, param_interp = self._get_interpolated(
+                            flh,
+                            fls,
+                            param,
+                            subregion=subregion,
+                            interp_debug=plot_interp_debug,
+                            plot_line_ax=plot_line_ax if plot_lines else None,
+                        )
+
+                        param_values[radial_index, poloidal_indices] = param_interp
+                except Exception as e:
+                    print(f"\nError interpolating {param} for region {region}, sepadd {sepadd}: {e}")
+                    pass
+
 
             print("")
 

--- a/code_comparison/interpolate.py
+++ b/code_comparison/interpolate.py
@@ -13,6 +13,8 @@ class interpolateSOLPStoHermes:
         self.ds = ds
         self.solps = solps
 
+        
+
         self.region_settings = {
             "inner_lower_upstream": dict(
                 radial_start_region="imp",
@@ -139,12 +141,16 @@ class interpolateSOLPStoHermes:
     def interpolate(self, param, regions, plot_lines=False, plot_interp_debug=False):
         ds = self.ds
 
+
         if plot_lines:
             _, plot_line_ax = plt.subplots(figsize=(10, 20), dpi=100)
             ds["Ne"].hermesm.clean_guards().bout.polygon(
                 ax=plot_line_ax,
                 **self.polygon_settings,
             )
+
+            self.plot_line_ax = plot_line_ax
+            self.plot_lines = True
 
             self.solps.plot_2d("Ne", ax =plot_line_ax, grid_only = True, linecolor = "red")
             plot_line_ax.set_xlim(*self.polygon_xlim)
@@ -216,6 +222,10 @@ class interpolateSOLPStoHermes:
             region=spec["radial_start_region"],
         )
 
+    
+        if self.plot_lines:
+            self.plot_line_ax.plot(hermes_radial_slice["R"], hermes_radial_slice["Z"], lw=2, marker="o", c="cyan", ms=3)
+
         if spec["radial_subset"] == "sol":
             hermes_candidate_rings = hermes_radial_slice[hermes_radial_slice["Srad"] > 0]
             solps_available_rings = solps_radial_slice[solps_radial_slice["dist"] > 0]
@@ -284,6 +294,7 @@ class interpolateSOLPStoHermes:
             sepadd=sepadd,
             radial_start_region=spec["radial_start_region"],
             interpolate_midplane=interpolate_midplane,
+            
             debug = False
         )
         fls = self.solps.get_1d_poloidal_data(
@@ -292,6 +303,7 @@ class interpolateSOLPStoHermes:
             sepdist=sepdist,
             interpolate_midplane=interpolate_midplane,
             radial_start_region=spec["radial_start_region"],
+            extrapolate_radial = True,
             debug = False
         )
         # raise SystemExit
@@ -370,7 +382,7 @@ class interpolateSOLPStoHermes:
         out = self._interpolate_values(fls["Spol"], fls[param], flh["Spol"])
 
         if interp_debug:
-            fig, ax = plt.subplots()
+            ax = interp_debug_ax
             ax.plot(flh["Spol"], flh[param], label="Hermes", marker="o")
             ax.plot(fls["Spol"], fls[param], label="SOLPS", marker="x")
             ax.plot(flh["Spol"], out, label="Interpolated", marker="o")
@@ -393,7 +405,11 @@ class interpolateSOLPStoHermes:
     
 
     
-    def check_1d(self, ds_interp, param):
+    def plot_1d_check(self, ds_interp, param):
+
+        """
+        Series of 1D plots to check interpolation quality for a single parameter
+        """
 
         lw = 1
         style_SOLPS = dict(c="k", marker="o", linewidth = lw, label="SOLPS")
@@ -426,16 +442,29 @@ class interpolateSOLPStoHermes:
             ax.set_title(f"{hermes_region}, sepdist={sepdist}")
             ax.legend(fontsize = "x-small")
 
-        num_plots = 5
-        fig, axes = plt.subplots(2,num_plots, figsize=(num_plots*5,10))
+        num_cols = 6
+        fig, axes = plt.subplots(3,num_cols, figsize=(num_cols*5,15))
 
         plot_radial_result(axes[0,0], "Ne", "omp", "omp")
         plot_radial_result(axes[0,1], "Ne", "imp", "imp")
         plot_radial_result(axes[0,2], "Ne", "inner_lower_target", "inner_lower_target")
-        plot_radial_result(axes[0,3], "Ne", "outer_lower_target", "outer_lower_target")
+        plot_radial_result(axes[0,3], "Ne", "inner_upper_target", "inner_upper_target")
+        plot_radial_result(axes[0,4], "Ne", "outer_lower_target", "outer_lower_target")
+        plot_radial_result(axes[0,5], "Ne", "outer_upper_target", "outer_upper_target")
 
         # These sepdist values are at Hermes-3 cell centres
-        plot_parallel_result(axes[1,0], "Ne", 0.000202, "outer_lower_sol", "outer_lower_sol")
-        plot_parallel_result(axes[1,1], "Ne", 0.014630, "outer_lower_sol", "outer_lower_sol")
         plot_parallel_result(axes[1,2], "Ne", 0.000202, "inner_lower_sol", "inner_lower_sol")
-        plot_parallel_result(axes[1,3], "Ne", 0.014630, "inner_lower_sol", "inner_lower_sol")
+        plot_parallel_result(axes[1,3], "Ne", 0.000202, "inner_upper_sol", "inner_upper_sol")
+        plot_parallel_result(axes[1,4], "Ne", 0.000202, "outer_lower_sol", "outer_lower_sol")
+        plot_parallel_result(axes[1,5], "Ne", 0.000202, "outer_upper_sol", "outer_upper_sol")
+
+        plot_parallel_result(axes[2,2], "Ne", 0.014630, "inner_lower_sol", "inner_lower_sol")
+        plot_parallel_result(axes[2,3], "Ne", 0.014630, "inner_upper_sol", "inner_upper_sol")
+        plot_parallel_result(axes[2,4], "Ne", 0.014630, "outer_lower_sol", "outer_lower_sol")
+        plot_parallel_result(axes[2,5], "Ne", 0.014630, "outer_upper_sol", "outer_upper_sol")
+
+
+
+        # plot_parallel_result(axes[1,2], "Ne", 0.014630, "outer_lower_sol", "outer_lower_sol")
+        # plot_parallel_result(axes[1,3], "Ne", 0.000202, "inner_lower_sol", "inner_lower_sol")
+        # plot_parallel_result(axes[1,4], "Ne", 0.014630, "inner_lower_sol", "inner_lower_sol")

--- a/code_comparison/solps_helpers.py
+++ b/code_comparison/solps_helpers.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+
+def _read_field(fid, fieldname, dims, cast, validate_dims=True):
+    """Read a single SOLPS text field from an open file handle.
+
+    Parameters
+    ----------
+    fid : file object
+        Open file positioned anywhere before the requested field.
+    fieldname : str
+        Name of the field to search for in the file.
+    dims : int or list[int]
+        Expected output shape. Scalars may be passed as a single integer.
+    cast : callable
+        Element-wise converter, typically int or float.
+    validate_dims : bool
+        If True, check that the field size declared in the file matches dims.
+
+    Returns
+    -------
+    numpy.ndarray
+        Parsed field data, reshaped in Fortran order for array-valued fields.
+    """
+
+    line = fid.readline()
+    while fieldname not in line:
+        if line == "":
+            raise ValueError(f"EOF reached without finding {fieldname}.")
+        line = fid.readline()
+
+    numin = int(line.split()[2])
+    expected = int(np.array(dims).prod())
+    if validate_dims and numin != expected:
+        raise ValueError(f"inconsistent number of input elements for {fieldname}")
+
+    field = np.zeros(numin)
+    iin = 0
+    while iin < numin:
+        values = fid.readline().split()
+        if not values:
+            break
+        for iil, value in enumerate(values):
+            field[iin + iil] = cast(value)
+        iin += len(values)
+
+    if iin != numin:
+        raise ValueError(f"unexpected EOF while reading {fieldname}")
+
+    if isinstance(dims, list) and len(dims) > 1:
+        field = np.reshape(field, tuple(dims), order="F")
+
+    return field
+
+
+def read_ifield(fid=None, fieldname=None, dims=None):
+    """Read an integer SOLPS field from a text file."""
+
+    validate_dims = fieldname != "nx,ny"
+    return _read_field(fid, fieldname, dims, int, validate_dims=validate_dims)
+
+
+def read_rfield(fid=None, fieldname=None, dims=None):
+    """Read a floating-point SOLPS field from a text file."""
+
+    return _read_field(fid, fieldname, dims, float)

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -605,6 +605,9 @@ class SOLPScase():
         
         if grid_only is True:
             data = np.zeros_like(self.bal["te"])
+
+        if grid_only is True and linewidth == 0:
+            linewidth = 0.1
         
         if absolute:
             data = np.abs(data)

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -1242,15 +1242,18 @@ class SOLPScase():
         df["Spar"] -= df["Spar"].iloc[0]   # Now 0 is at Z = 0
         
         
-        ## Value of X-point column will be 1 in the cell just downstream of X-point
-        # df["Xpoint"] = ""
-        Xpoint_index = df.index[-self.psel[f"{region}_xpoint_fromtarget"]+1]
-        
-        df.loc[:Xpoint_index, "region"] = "upstream"
-        df.loc[Xpoint_index:, "region"] = "divertor"
-        
-        df["Xpoint"] = 0
-        df.loc[Xpoint_index, "Xpoint"] = 1
+        if "sol" in region:
+            ## Value of X-point column will be 1 in the cell just downstream of X-point
+            Xpoint_index = df.index[-self.psel[f"{region.replace("_sol", "")}_xpoint_fromtarget"]+1]
+            
+            df.loc[:Xpoint_index, "region"] = "upstream"
+            df.loc[Xpoint_index:, "region"] = "divertor"
+            
+            df["Xpoint"] = 0
+            df.loc[Xpoint_index, "Xpoint"] = 1
+
+        else:
+            df["region"] = "core"
         
         # df.loc[Xpoint_index + 1, "Xpoint"] = "before"
         # df.loc[Xpoint_index, "Xpoint"] = "after"

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -1003,7 +1003,7 @@ class SOLPScase():
 
         # Get midplane radial profile to find fractional ring index for desired sepdist
         radial_slice = self.get_1d_radial_data(
-            ["fpsi"], region=radial_start_region, keep_geometry=True, guards=True
+            ["fpsi"], region=radial_start_region, keep_geometry=True, guards=False
         )
 
 
@@ -1015,19 +1015,8 @@ class SOLPScase():
             )(sepdist)
         )
 
-
-        # Get poloidal indices for the region (use sepadd=0 just to get the slice)
-        test_selector = self.make_custom_sol_ring(region, i=0)
-        pol_slice = test_selector[0]
-
-        nx = self.g["nx"]
-        if isinstance(pol_slice, slice):
-            pol_indices = list(range(*pol_slice.indices(nx)))
-        else:
-            pol_indices = [pol_slice]
-
-        ny = self.g["ny"]
-        y_indices = np.arange(ny, dtype=float)
+        # Get poloidal indices for the region 
+        pol_indices = np.arange(self.g["nx"])[self.psel[region]]
 
         geom_params = ["R", "Z", "hx", "Btot", "Bpol", "vol", "fpsi"]
         all_param_names = list(

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -196,7 +196,7 @@ class SOLPScase():
         # s["outer_lower_target_guard"] = (-1, slice(None,None))
         
         # First SOL rings
-        for name in ["outer", "outer_lower", "outer_upper", "inner", "inner_lower", "inner_upper"]:
+        for name in ["outer_sol", "outer_lower_sol", "outer_upper_sol", "inner_sol", "inner_lower_sol", "inner_upper_sol"]:
             s[name] = self.make_custom_sol_ring(name, i = 0)
             
         self.get_species()
@@ -380,7 +380,7 @@ class SOLPScase():
         Inputs
         ------
             name, str:
-                "outer", "outer_lower", "outer_upper", "inner", "inner_lower", "inner_upper"
+                "outer_sol", "outer_lower_sol", "outer_upper_sol", "inner_sol", "inner_lower_sol", "inner_upper_sol"
                 "inner_upper_leg", "outer_upper_leg", "inner_lower_leg", "outer_lower_leg"
             i, int: 
                 SOL ring index (0 = first inside SOL) 
@@ -409,23 +409,23 @@ class SOLPScase():
         
         ## Note: all of these start beyond the midplane so that you can interpolate to Z=0 later
         selections = {}
-        selections["outer"] =       (slice(self.g["upper_break"],None), yid)
-        selections["outer_lower"] = (slice(self.g["omp"]+1-1,None), yid)
-        selections["outer_upper"] = (slice(self.g["upper_break"], self.g["omp"]+1+1), yid)
+        selections["outer_sol"] =       (slice(self.g["upper_break"],None), yid)
+        selections["outer_lower_sol"] = (slice(self.g["omp"]+1-1,None), yid)
+        selections["outer_upper_sol"] = (slice(self.g["upper_break"], self.g["omp"]+1+1), yid)
         
         for leg_name in ["inner_upper_leg", "outer_upper_leg", "inner_lower_leg", "outer_lower_leg"]:
             selections[leg_name] = (self.psel[leg_name], yid)
         
         
-        selections["inner"] =       (slice(1, self.g["upper_break"]), yid)
-        selections["inner_lower"] = (slice(1, self.g["imp"]+1), yid)
-        selections["inner_upper"] = (slice(self.g["imp"]-1, self.g["upper_break"]), yid)
+        selections["inner_sol"] =       (slice(1, self.g["upper_break"]), yid)
+        selections["inner_lower_sol"] = (slice(1, self.g["imp"]+1), yid)
+        selections["inner_upper_sol"] = (slice(self.g["imp"]-1, self.g["upper_break"]), yid)
 
         
         if name in selections.keys():
             return selections[name]
         else:
-            raise Exception(f"Region {name} not supported. \n Try outer, outer_lower, outer_upper, inner, inner_lower, inner_upper")
+            raise Exception(f"Region {name} not supported. \n Try outer_sol, outer_lower_sol, outer_upper_sol, inner_sol, inner_lower_sol, inner_upper_sol")
     
 
         
@@ -792,7 +792,7 @@ class SOLPScase():
         Parameters
         ----------
         params : list of str, parameters to extract
-        region : str, region name (inner_lower, inner_upper, outer_lower, outer_upper)
+        region : str, region name (inner_lower_sol, inner_upper_sol, outer_lower_sol, outer_upper_sol)
         sepdist : float, separatrix distance in [m]
 
         Returns
@@ -888,10 +888,10 @@ class SOLPScase():
         """
 
         if "lower" in region or "upper" in region:
-            raise ValueError("Region should be 'inner' or 'outer' for double leg data, not 'inner_lower' etc.")
+            raise ValueError("Region should be 'inner_sol' or 'outer_sol' for double leg data, not 'inner_lower_sol' etc.")
 
-        df_lower = self.get_1d_poloidal_data(params, region=f"{region}_lower", **kwargs)
-        df_upper = self.get_1d_poloidal_data(params, region=f"{region}_upper", **kwargs)
+        df_lower = self.get_1d_poloidal_data(params, region=f"{region}_lower_sol", **kwargs)
+        df_upper = self.get_1d_poloidal_data(params, region=f"{region}_upper_sol", **kwargs)
         fl = pd.concat([df_upper.iloc[::-1], df_lower.iloc[1:]], ignore_index = True)
 
         return fl
@@ -899,7 +899,7 @@ class SOLPScase():
     def get_1d_poloidal_data(
         self,
         params,
-        region="outer_lower",
+        region="outer_lower_sol",
         sepadd=None,
         sepdist=None,
         target_first=False,
@@ -911,7 +911,7 @@ class SOLPScase():
         Note that the balance file shape is a transpose of the geometry shape (e.g. crx)
         and contains guard cells, so R and Z are incorrect because they don't have guards
         R and Z are provided for checking field line location only.
-        only outer_lower region is provided at the moment.
+        only outer_lower_sol region is provided at the moment.
         sepadd is the ring index number with sepadd = 0 being the separatrix
         interpolate_radial: if True and sepdist is given, interpolate across rings to get
             data at the exact sepdist rather than snapping to the closest ring.
@@ -1012,7 +1012,7 @@ class SOLPScase():
             df["apar"] = vol / dSpar
 
 
-        if any([name in region for name in ["outer_upper", "inner_lower"]]):
+        if any([name in region for name in ["outer_upper_sol", "inner_lower_sol"]]):
             df["Spol"] = df["Spol"].iloc[-1] - df["Spol"]
             df["Spar"] = df["Spar"].iloc[-1] - df["Spar"]
             df = df.iloc[::-1].reset_index(drop = True)
@@ -1173,7 +1173,7 @@ class SOLPScase():
         """
         Extract cooling curve from a single SOL ring
         Inputs: species (e.g. Ar). Must calculate RAr and fAr first (get radiation stats)
-        region: string  like "outer_lower"
+        region: string  like "outer_lower_sol"
         sepadd: no. sol rings beyond separatrix
         order: order of polynomial fit
         plot: debug plot
@@ -1283,7 +1283,7 @@ class SOLPScase():
                                   sepadd = sepadd, region = region, target_first = target_first)
                                   
 
-        if "outer_upper" in region or "inner_lower" in region:
+        if "outer_upper_sol" in region or "inner_lower_sol" in region:
             mult = -1
         else:
             mult = 1
@@ -1349,7 +1349,7 @@ class SOLPScase():
         Inputs
         ------
         sepadd: no. of SOL rings beyond separatrix
-        region: string like "outer_lower"
+        region: string like "outer_lower_sol"
         impurity: string like "N"
         method: usually qpar_tot
         threshold: fraction of max value to define front
@@ -1397,7 +1397,7 @@ class SOLPScase():
         fline_right = self.get_1d_poloidal_data(fluxlist, sepadd = sepadd+1, region = region, target_first = True)
         
         for param in fluxlist:
-            if "inner_lower" in region or "outer_upper" in region:
+            if "inner_lower_sol" in region or "outer_upper_sol" in region:
                 fline[param] *= -1
                 fline_right[param] *= -1
                 
@@ -1478,7 +1478,7 @@ class SOLPScase():
         fline_div = fline.query(f"region == 'divertor' & Te > {Te_threshold}")   # Cells below X-point
         fline_right_div = fline_right.query(f"region == 'divertor' & Spar > {fline_div['Spar'].min()}")  # Same filter on RHS fline   
         
-        if any([x in region for x in ["inner_lower"]]):
+        if any([x in region for x in ["inner_lower_sol"]]):
             mult = -1
         else:
             mult = 1

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -1041,13 +1041,34 @@ class SOLPScase():
         )
 
 
+        radial_dist_min = radial_slice["dist"].min()
+        radial_dist_max = radial_slice["dist"].max()
+        if sepdist < radial_dist_min or sepdist > radial_dist_max:
+            print(
+                f"Warning: desired sepdist {sepdist} is outside the range of available sepdist values "
+                f"({radial_dist_min} to {radial_dist_max}) in radial start region {radial_start_region}."
+            )
+
+            if extrapolate_radial:
+                print("Extrapolating sepdist to psi...")
+
         # Interpolate to find fractional ring index at the desired separatrix distance
-        psi = float(
-            scipy.interpolate.interp1d(
-                radial_slice["dist"].values,
-                radial_slice["fpsi"].values,
-            )(sepdist)
-        )
+        if extrapolate_radial:
+            psi = float(
+                scipy.interpolate.interp1d(
+                    radial_slice["dist"].values,
+                    radial_slice["fpsi"].values,
+                    bounds_error=False,
+                    fill_value="extrapolate",
+                )(sepdist)
+            )
+        else:
+            psi = float(
+                scipy.interpolate.interp1d(
+                    radial_slice["dist"].values,
+                    radial_slice["fpsi"].values,
+                )(sepdist)
+            )
 
         # Get poloidal indices for the region 
         pol_indices = np.arange(self.g["nx"])[self.psel[region]]

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -51,7 +51,7 @@ import ipywidgets as widgets
 
 
 class SOLPScase():
-    def __init__(self, path):
+    def __init__(self, path, path_b2fgmtry = None):
         
         """
         Note that everything in the balance file is in the Y, X convention unlike the
@@ -250,12 +250,13 @@ class SOLPScase():
         for name in ["outer_sol", "outer_lower_sol", "outer_upper_sol", "inner_sol", "inner_lower_sol", "inner_upper_sol"]:
             s[name] = (self.psel[name], self.g["sep"])
 
-        self.read_b2fgmtry()
-            
+        self.read_b2fgmtry(path_b2fgmtry)
+        # self.reverse_velocities()  # Positive velocity is towards outer target
         self.get_species()
         self.derive_data()
+        
 
-    def read_b2fgmtry(self, path = None, verbose = False, strict = False):
+    def read_b2fgmtry(self, path = None, verbose = False, strict = True):
         """
         Read b2fgmtry and merge supplemental geometry data into self.g.
 
@@ -435,8 +436,7 @@ class SOLPScase():
             
         
         print(f"Added total radiation, density and fraction for {species_name}")
-        
-    
+
     def derive_data(self):
         """
         Add new derived variables to the balance file
@@ -511,7 +511,7 @@ class SOLPScase():
         
         # flux = bal["fnax_D+1_tot"] / (bal["vol"] / bal["
         
-        bal["Vd+"] = bal["ua"][:,:,1]  # Note first species is fluid neutral
+        bal["Vd+"] = bal["ua"][:,:,1] * -1  # Note first species is fluid neutral
         bal["NVd+"] = bal["Vd+"] * bal["Ne"] * Mi  # Parallel momentum flux kg/m2/s
         bal["M"] = np.abs(bal["Vd+"] / np.sqrt((bal["Te"]*qe + bal["Td+"]*qe)/Mi))  # Mach number
         

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -182,8 +182,27 @@ class SOLPScase():
         psel["inner_upper_divertor"] = slice(self.g["leftcut"][1]-2, self.g["upper_break"]-1)
         psel["outer_lower_divertor"] = slice(self.g["rightcut"][0]+2, self.g["nx"])
         psel["inner_lower_divertor"] = slice(0, self.g["leftcut"][0]+2)
-        psel["upper_pfr"] = np.r_[psel["inner_upper_divertor"], psel["outer_upper_divertor"]]
+        # psel["upper_pfr"] = np.r_[psel["inner_upper_divertor"], psel["outer_upper_divertor"]]
+        psel["upper_pfr"] = np.r_[psel["outer_upper_divertor"], psel["inner_upper_divertor"]]
         psel["lower_pfr"] = np.r_[psel["inner_lower_divertor"], psel["outer_lower_divertor"]]
+
+        psel["outer_upper_pfr"] = psel["outer_upper_divertor"]
+        psel["inner_upper_pfr"] = psel["inner_upper_divertor"]
+        psel["outer_lower_pfr"] = psel["outer_lower_divertor"]
+        psel["inner_lower_pfr"] = psel["inner_lower_divertor"]
+
+        # These are the poloidal selections used to construct custom rings.
+        psel["outer_sol"] = slice(self.g["upper_break"], None)
+        psel["outer_lower_sol"] = slice(self.g["omp"], None)
+        psel["outer_upper_sol"] = slice(self.g["upper_break"], self.g["omp"] + 2)
+        psel["inner_sol"] = slice(1, self.g["upper_break"])
+        psel["inner_lower_sol"] = slice(1, self.g["imp"] + 1)
+        psel["inner_upper_sol"] = slice(self.g["imp"] - 1, self.g["upper_break"])
+        
+        psel["inner_core"] = slice(self.g["leftcut"][0] + 2, self.g["leftcut"][1] - 1)
+        psel["outer_core"] = slice(self.g["rightcut"][1] + 2, self.g["rightcut"][0] + 2)
+        psel["core"] = np.r_[psel["outer_core"], psel["inner_core"]]
+
         psel["omp"] = omp
         psel["imp"] = imp
         
@@ -192,6 +211,19 @@ class SOLPScase():
         psel["inner_upper_xpoint"] = g["xcut"][1]
         psel["outer_upper_xpoint"] = g["xcut"][3]
         psel["outer_lower_xpoint"] = g["xcut"][4]+1
+
+        # Upstream selections run from the midplane to the X-point and
+        # overlap with the divertor selections at the X-point cell.
+        psel["inner_lower_upstream"] = slice(psel["inner_lower_xpoint"]+1, self.g["imp"])
+        psel["inner_upper_upstream"] = slice(self.g["imp"], psel["inner_upper_xpoint"])
+        psel["outer_upper_upstream"] = slice(psel["outer_upper_xpoint"]+1, self.g["omp"] + 1)
+        psel["outer_lower_upstream"] = slice(self.g["omp"]+1, psel["outer_lower_xpoint"])
+
+        # Includes one cell beyond the midplane
+        psel["inner_lower_upstream_extra"] = slice(psel["inner_lower_xpoint"]+1, self.g["imp"]+1)
+        psel["inner_upper_upstream_extra"] = slice(self.g["imp"]-1, psel["inner_upper_xpoint"]+1)
+        psel["outer_upper_upstream_extra"] = slice(psel["outer_upper_xpoint"]+1, self.g["omp"] + 2)
+        psel["outer_lower_upstream_extra"] = slice(self.g["omp"], psel["outer_lower_xpoint"])
         
         # These are for 1d poloidal data getter
         psel["inner_lower_xpoint_fromtarget"] = psel["inner_lower_xpoint"] - psel["inner_lower_target_guard"] + 1
@@ -207,8 +239,7 @@ class SOLPScase():
         
         # First SOL rings
         for name in ["outer_sol", "outer_lower_sol", "outer_upper_sol", "inner_sol", "inner_lower_sol", "inner_upper_sol"]:
-            s[name] = self.make_custom_sol_ring(name, i = 0)
-            self.psel[name] = self.make_custom_sol_ring(name, i = 0)[0]
+            s[name] = (self.psel[name], self.g["sep"])
 
         self.read_b2fgmtry()
             
@@ -506,6 +537,7 @@ class SOLPScase():
         ------
             name, str:
                 "outer_sol", "outer_lower_sol", "outer_upper_sol", "inner_sol", "inner_lower_sol", "inner_upper_sol"
+                "outer_lower_upstream", "outer_upper_upstream", "inner_lower_upstream", "inner_upper_upstream"
                 "inner_upper_divertor", "outer_upper_divertor", "inner_lower_divertor", "outer_lower_divertor"
             i, int: 
                 SOL ring index (0 = first inside SOL) 
@@ -531,26 +563,14 @@ class SOLPScase():
             raise ValueError("Use i or sep_dist but not both")
         if i == None and sep_dist == None:
             raise ValueError("Provide either i or sep_dist")
-        
-        ## Note: all of these start beyond the midplane so that you can interpolate to Z=0 later
-        selections = {}
-        selections["outer_sol"] =       (slice(self.g["upper_break"],None), yid)
-        selections["outer_lower_sol"] = (slice(self.g["omp"]+1-1,None), yid)
-        selections["outer_upper_sol"] = (slice(self.g["upper_break"], self.g["omp"]+1+1), yid)
-        
-        for leg_name in ["inner_upper_divertor", "outer_upper_divertor", "inner_lower_divertor", "outer_lower_divertor"]:
-            selections[leg_name] = (self.psel[leg_name], yid)
-        
-        
-        selections["inner_sol"] =       (slice(1, self.g["upper_break"]), yid)
-        selections["inner_lower_sol"] = (slice(1, self.g["imp"]+1), yid)
-        selections["inner_upper_sol"] = (slice(self.g["imp"]-1, self.g["upper_break"]), yid)
 
-        
-        if name in selections.keys():
-            return selections[name]
-        else:
-            raise Exception(f"Region {name} not supported. \n Try outer_sol, outer_lower_sol, outer_upper_sol, inner_sol, inner_lower_sol, inner_upper_sol")
+        selector = self.psel.get(name)
+        if selector is None or np.isscalar(selector):
+            raise Exception(
+                f"Region {name} not supported for custom ring selection"
+            )
+
+        return (selector, yid)
     
 
         
@@ -988,7 +1008,7 @@ class SOLPScase():
         df : DataFrame with R, Z, hx, Btot, Bpol, vol and requested params
         """
 
-        if "sol" in region:
+        if any([name in region for name in ["sol", "upstream", "divertor"]]):
             if sepdist < 0:
                 raise ValueError("sepdist must be positive for SOL regions")
         else:
@@ -997,7 +1017,15 @@ class SOLPScase():
         
         ## Get radial slice to figure out field line starting point based on sepdist
         if radial_start_region is None:
-            if "outer" in region:
+            if region == "outer_lower_pfr":
+                radial_start_region = "outer_lower_target"
+            elif region == "outer_upper_pfr":
+                radial_start_region = "outer_upper_target"
+            elif region == "inner_lower_pfr":
+                radial_start_region = "inner_lower_target"
+            elif region == "inner_upper_pfr":
+                radial_start_region = "inner_upper_target"
+            elif "outer" in region:
                 radial_start_region = "omp"
             elif "inner" in region:
                 radial_start_region = "imp"
@@ -1052,6 +1080,7 @@ class SOLPScase():
         
         df = pd.DataFrame()
 
+        # Make figure, plot grid
         if debug:
             fig, ax = plt.subplots(dpi = 150)
             self.plot_2d("Te", ax = ax, grid_only = True)
@@ -1059,8 +1088,10 @@ class SOLPScase():
 
             radial = self.get_1d_radial_data(params = all_param_names, poloidal_index = pol_i)
             
+            # Plot radial slices
             if debug:
-                ax.plot(radial["R"], radial["Z"], "o", markersize = 3, alpha = 0.5)
+                ax.plot(radial["R"], radial["Z"], "o", markersize = 1, alpha = 0.5)
+
             for param_name in all_param_names:
                 # radial_values = lookup[param_name][pol_i, :]
 
@@ -1068,8 +1099,11 @@ class SOLPScase():
                     scipy.interpolate.interp1d(radial["fpsi"], radial[param_name])(psi)
                 )
             
-            if debug:
-                ax.plot(df["R"], df["Z"], c = "deeppink")
+        # Plot field line
+        if debug:
+            ax.plot(df["R"], df["Z"], c = "deeppink")
+            ax.plot(df.iloc[0]["R"], df.iloc[0]["Z"], "o", markersize = 5, c = "green")
+            ax.plot(df.iloc[-1]["R"], df.iloc[-1]["Z"], "o", markersize = 5, c = "red")
 
         return df
 
@@ -1137,9 +1171,29 @@ class SOLPScase():
         elif sepadd is not None and sepdist is not None:
             raise ValueError("Must use either index i or separatrix distance sepdist, not both")
         
-        print(region)
+        if "divertor" in region and interpolate_midplane:
+            raise ValueError("Interpolate midplane = true should not be used for divertor regions!")
+
         if any([x in region for x in ["pfr", "core"]]) and interpolate_midplane:
             raise ValueError("Interpolate midplane = true should not be used for PFR or core regions!")
+        
+        if radial_start_region == "auto":
+            if region == "outer_lower_pfr":
+                radial_start_region = "outer_lower_target"
+            elif region == "outer_upper_pfr":
+                radial_start_region = "outer_upper_target"
+            elif region == "inner_lower_pfr":
+                radial_start_region = "inner_lower_target"
+            elif region == "inner_upper_pfr":
+                radial_start_region = "inner_upper_target"
+            elif "outer" in region:
+                radial_start_region = "omp"
+            elif "inner" in region:
+                radial_start_region = "imp"
+            elif region == "lower_pfr":
+                radial_start_region = "outer_lower_target"
+            elif region == "upper_pfr":
+                radial_start_region = "outer_upper_target"
 
         # Radial interpolation path: interpolate across rings for exact sepdist
         if interpolate_radial:
@@ -1153,7 +1207,7 @@ class SOLPScase():
                 region,
                 sepdist,
                 radial_start_region=radial_start_region,
-                debug=debug,
+                debug=False,
             )
 
             hx = df["hx"].values
@@ -1223,8 +1277,13 @@ class SOLPScase():
             df["Spar"] = np.cumsum(dSpar)
             df["apar"] = vol / dSpar
 
-
-        if any([name in region for name in ["outer_upper_sol", "inner_lower_sol"]]):
+        # Flip certain regions to make sure we always end at a guard cell
+        if any([name in region for name in [
+            "outer_upper_sol", "inner_lower_sol",
+            "outer_upper_upstream", "inner_lower_upstream",
+            "outer_upper_divertor", "inner_lower_divertor",
+            "outer_upper_pfr", "inner_lower_pfr"
+            ]]):
             df["Spol"] = df["Spol"].iloc[-1] - df["Spol"]
             df["Spar"] = df["Spar"].iloc[-1] - df["Spar"]
             df = df.iloc[::-1].reset_index(drop = True)
@@ -1233,11 +1292,12 @@ class SOLPScase():
         if interpolate_midplane:
             for param in df.columns.drop("Z"):
                 interp = scipy.interpolate.interp1d(df["Z"], df[param], kind = "linear")
-                df.loc[0, param] = interp(0)
-            df.loc[0,"Z"] = 0  
+                df.loc[df.index[0], param] = interp(0)
+            df.loc[df.index[0],"Z"] = 0  
 
             df["Spol"] -= df["Spol"].iloc[0]   # Now 0 is at Z = 0
             df["Spar"] -= df["Spar"].iloc[0]   # Now 0 is at Z = 0
+
         
         
         if "sol" in region:
@@ -1250,21 +1310,34 @@ class SOLPScase():
             df["Xpoint"] = 0
             df.loc[Xpoint_index, "Xpoint"] = 1
 
+        elif "upstream" in region:
+            df["region"] = "upstream"
+
+        elif "divertor" in region:
+            df["region"] = "divertor"
+
         elif "pfr" in region:
             df["region"] = "pfr"
         else:
             df["region"] = "core"
         
 
-        if not guards:
+        if not guards and any([x in region for x in ["sol", "divertor", "pfr"]]):
             df = df.iloc[:-1]
 
-        if target_first:
+        if target_first and any([x in region for x in ["sol", "divertor", "pfr"]]):
             df["Spol"] = df["Spol"].iloc[-1] - df["Spol"]
             df["Spar"] = df["Spar"].iloc[-1] - df["Spar"]
             df = df.iloc[::-1]
         
         df = df.reset_index(drop = True)
+
+        if debug:
+            fig, ax = plt.subplots(dpi = 150)
+            self.plot_2d("Te", ax = ax, grid_only = True)
+            ax.plot(df["R"], df["Z"], "-", c = "deeppink", markersize = 3)
+            ax.plot(df.iloc[0]["R"], df.iloc[0]["Z"], "o", markersize = 5, c = "green")
+            ax.plot(df.iloc[-1]["R"], df.iloc[-1]["Z"], "o", markersize = 5, c = "red")
         
         return df
     

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -1128,17 +1128,18 @@ class SOLPScase():
         if region == "outer" or region == "inner":
             raise ValueError("Only one divertor leg at a time is supported for now, specify upper or lower")
         
-        if type(params) == str:
+        if isinstance(params, str):
             params = [params]
             
-        if sepadd == None and sepdist == None:
+        if sepadd is None and sepdist is None:
             raise ValueError("Must use either index i or separatrix distance sepdist")
         
-        elif sepadd != None and sepdist != None:
+        elif sepadd is not None and sepdist is not None:
             raise ValueError("Must use either index i or separatrix distance sepdist, not both")
         
-        if region in ["pfr", "core"] and interpolate_midplane:
-            raise ValueError("Interpolate midplane should not be used for PFR or core regions!")
+        print(region)
+        if any([x in region for x in ["pfr", "core"]]) and interpolate_midplane:
+            raise ValueError("Interpolate midplane = true should not be used for PFR or core regions!")
 
         # Radial interpolation path: interpolate across rings for exact sepdist
         if interpolate_radial:

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -670,8 +670,8 @@ class SOLPScase():
 
         R = self.g["crx"][:,:,0]
         Z = self.g["cry"][:,:,0]
-        ax.plot(R[self.s["inner"]], Z[self.s["inner"]], **kwargs)
-        ax.plot(R[self.s["outer"]], Z[self.s["outer"]], **kwargs)
+        ax.plot(R[self.s["inner_sol"]], Z[self.s["inner_sol"]], **kwargs)
+        ax.plot(R[self.s["outer_sol"]], Z[self.s["outer_sol"]], **kwargs)
         
     def get_1d_radial_data(
         self,

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -1228,13 +1228,14 @@ class SOLPScase():
             df = df.iloc[::-1].reset_index(drop = True)
 
         # Interpolate onto Z = 0
-        for param in df.columns.drop("Z"):
-            interp = scipy.interpolate.interp1d(df["Z"], df[param], kind = "linear")
-            df.loc[0, param] = interp(0)
-        df.loc[0,"Z"] = 0  
+        if interpolate_midplane:
+            for param in df.columns.drop("Z"):
+                interp = scipy.interpolate.interp1d(df["Z"], df[param], kind = "linear")
+                df.loc[0, param] = interp(0)
+            df.loc[0,"Z"] = 0  
 
-        df["Spol"] -= df["Spol"].iloc[0]   # Now 0 is at Z = 0
-        df["Spar"] -= df["Spar"].iloc[0]   # Now 0 is at Z = 0
+            df["Spol"] -= df["Spol"].iloc[0]   # Now 0 is at Z = 0
+            df["Spar"] -= df["Spar"].iloc[0]   # Now 0 is at Z = 0
         
         
         if "sol" in region:
@@ -1247,16 +1248,14 @@ class SOLPScase():
             df["Xpoint"] = 0
             df.loc[Xpoint_index, "Xpoint"] = 1
 
+        elif "pfr" in region:
+            df["region"] = "pfr"
         else:
             df["region"] = "core"
         
-        # df.loc[Xpoint_index + 1, "Xpoint"] = "before"
-        # df.loc[Xpoint_index, "Xpoint"] = "after"
-        # df["Xpoint"] = 1
 
         if not guards:
             df = df.iloc[:-1]
-
 
         if target_first:
             df["Spol"] = df["Spol"].iloc[-1] - df["Spol"]
@@ -1266,7 +1265,6 @@ class SOLPScase():
         df = df.reset_index(drop = True)
         
         return df
-        # return df[::-1]
     
     def find_param(self, name):
         """

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -506,7 +506,7 @@ class SOLPScase():
         ------
             name, str:
                 "outer_sol", "outer_lower_sol", "outer_upper_sol", "inner_sol", "inner_lower_sol", "inner_upper_sol"
-                "inner_upper_leg", "outer_upper_leg", "inner_lower_leg", "outer_lower_leg"
+                "inner_upper_divertor", "outer_upper_divertor", "inner_lower_divertor", "outer_lower_divertor"
             i, int: 
                 SOL ring index (0 = first inside SOL) 
             sep_dist, int
@@ -538,7 +538,7 @@ class SOLPScase():
         selections["outer_lower_sol"] = (slice(self.g["omp"]+1-1,None), yid)
         selections["outer_upper_sol"] = (slice(self.g["upper_break"], self.g["omp"]+1+1), yid)
         
-        for leg_name in ["inner_upper_leg", "outer_upper_leg", "inner_lower_leg", "outer_lower_leg"]:
+        for leg_name in ["inner_upper_divertor", "outer_upper_divertor", "inner_lower_divertor", "outer_lower_divertor"]:
             selections[leg_name] = (self.psel[leg_name], yid)
         
         

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -178,8 +178,8 @@ class SOLPScase():
         psel["outer_upper_target_guard"] = upper_break
         psel["outer_lower_target_guard"] = self.g["nx"]
 
-        psel["outer_upper_divertor"] = slice(self.g["upper_break"]+1, self.g["rightcut"][1]+2)
-        psel["inner_upper_divertor"] = slice(self.g["leftcut"][1]-2, self.g["upper_break"]-1)
+        psel["outer_upper_divertor"] = slice(self.g["upper_break"], self.g["rightcut"][1]+2)
+        psel["inner_upper_divertor"] = slice(self.g["leftcut"][1]-2, self.g["upper_break"])
         psel["outer_lower_divertor"] = slice(self.g["rightcut"][0]+2, self.g["nx"])
         psel["inner_lower_divertor"] = slice(0, self.g["leftcut"][0]+2)
         # psel["upper_pfr"] = np.r_[psel["inner_upper_divertor"], psel["outer_upper_divertor"]]
@@ -199,7 +199,7 @@ class SOLPScase():
         psel["inner_lower_sol"] = slice(1, self.g["imp"] + 1)
         psel["inner_upper_sol"] = slice(self.g["imp"] - 1, self.g["upper_break"])
         
-        psel["inner_core"] = slice(self.g["leftcut"][0] + 2, self.g["leftcut"][1] - 1)
+        psel["inner_core"] = slice(self.g["leftcut"][0] + 2, self.g["leftcut"][1] - 2)
         psel["outer_core"] = slice(self.g["rightcut"][1] + 2, self.g["rightcut"][0] + 2)
         psel["core"] = np.r_[psel["outer_core"], psel["inner_core"]]
 

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -991,6 +991,7 @@ class SOLPScase():
             region,
             sepdist,
             radial_start_region=None, 
+            extrapolate_radial = False,
             debug = False):
         """
         Returns poloidal data radially interpolated to an exact separatrix distance.
@@ -1002,6 +1003,8 @@ class SOLPScase():
         params : list of str, parameters to extract
         region : str, region name (inner_lower_sol, inner_upper_sol, outer_lower_sol, outer_upper_sol)
         sepdist : float, separatrix distance in [m]
+        radial_start_region : str, optional, radial region defining sepdist, ideally at start of field line
+        extrapolate_radial : bool, optional, whether to allow extrapolation beyond available psi on each radial slice
 
         Returns
         -------
@@ -1092,12 +1095,26 @@ class SOLPScase():
             if debug:
                 ax.plot(radial["R"], radial["Z"], "o", markersize = 1, alpha = 0.5)
 
-            for param_name in all_param_names:
-                # radial_values = lookup[param_name][pol_i, :]
+            if psi < radial["fpsi"].min() or psi > radial["fpsi"].max():
+                print(f"Warning: desired psi {psi} is outside the range of available psi values ({radial['fpsi'].min()} to {radial['fpsi'].max()}) at poloidal index {pol_i}.")
+            
+                if extrapolate_radial:
+                    print("Extrapolating...")
 
-                df.loc[pol_i, param_name] = float(
-                    scipy.interpolate.interp1d(radial["fpsi"], radial[param_name])(psi)
-                )
+            for param_name in all_param_names:
+
+                if extrapolate_radial:
+                    
+                    df.loc[pol_i, param_name] = float(
+                        scipy.interpolate.interp1d(radial["fpsi"], radial[param_name],
+                                                bounds_error = False,
+                                                fill_value = "extrapolate")(psi)
+                    )
+                
+                else:
+                    df.loc[pol_i, param_name] = float(
+                        scipy.interpolate.interp1d(radial["fpsi"], radial[param_name])(psi)
+                    )
             
         # Plot field line
         if debug:
@@ -1143,6 +1160,7 @@ class SOLPScase():
         guards=False,
         interpolate_midplane=True,
         interpolate_radial=True,
+        extrapolate_radial=False,
         debug=False,
     ):
         """
@@ -1208,6 +1226,7 @@ class SOLPScase():
                 sepdist,
                 radial_start_region=radial_start_region,
                 debug=False,
+                extrapolate_radial = extrapolate_radial
             )
 
             hx = df["hx"].values

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -171,17 +171,19 @@ class SOLPScase():
         psel["inner_lower_target"] = 1
         psel["inner_upper_target"] = upper_break -2
         psel["outer_upper_target"] = upper_break+1
-        psel["outer_lower_target"] = -2
+        psel["outer_lower_target"] = self.g["nx"] - 1
 
         psel["inner_lower_target_guard"] = 0
         psel["inner_upper_target_guard"] = upper_break -1
         psel["outer_upper_target_guard"] = upper_break
-        psel["outer_lower_target_guard"] = -1
+        psel["outer_lower_target_guard"] = self.g["nx"]
 
-        psel["outer_upper_leg"] = slice(self.g["upper_break"]+1, self.g["rightcut"][1]+2)
-        psel["inner_upper_leg"] = slice(self.g["leftcut"][1]-2, self.g["upper_break"]-1)
-        psel["outer_lower_leg"] = slice(self.g["rightcut"][0]+2, -1)
-        psel["inner_lower_leg"] = slice(0, self.g["leftcut"][0]+2)
+        psel["outer_upper_divertor"] = slice(self.g["upper_break"]+1, self.g["rightcut"][1]+2)
+        psel["inner_upper_divertor"] = slice(self.g["leftcut"][1]-2, self.g["upper_break"]-1)
+        psel["outer_lower_divertor"] = slice(self.g["rightcut"][0]+2, self.g["nx"])
+        psel["inner_lower_divertor"] = slice(0, self.g["leftcut"][0]+2)
+        psel["upper_pfr"] = np.r_[psel["inner_upper_divertor"], psel["outer_upper_divertor"]]
+        psel["lower_pfr"] = np.r_[psel["inner_lower_divertor"], psel["outer_lower_divertor"]]
         psel["omp"] = omp
         psel["imp"] = imp
         
@@ -202,18 +204,11 @@ class SOLPScase():
         s = self.s = {}
         for location in psel.keys():
             s[location] = (psel[location], slice(None, None))
-        # s["inner_lower_target"] = (1, slice(None,None))
-        # s["inner_lower_target_guard"] = (0, slice(None,None))
-        # s["inner_upper_target"] = (upper_break-2, slice(None,None))
-        # s["inner_upper_target_guard"] = (upper_break-1, slice(None,None))
-        # s["outer_upper_target"] = (upper_break+1, slice(None,None))
-        # s["outer_upper_target_guard"] = (upper_break, slice(None,None))
-        # s["outer_lower_target"] = (-2, slice(None,None))
-        # s["outer_lower_target_guard"] = (-1, slice(None,None))
         
         # First SOL rings
         for name in ["outer_sol", "outer_lower_sol", "outer_upper_sol", "inner_sol", "inner_lower_sol", "inner_upper_sol"]:
             s[name] = self.make_custom_sol_ring(name, i = 0)
+            self.psel[name] = self.make_custom_sol_ring(name, i = 0)[0]
 
         self.read_b2fgmtry()
             

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -15,6 +15,11 @@ import pickle
 import matplotlib as mpl
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
+try:
+    from code_comparison.solps_helpers import read_ifield, read_rfield
+except ImportError:
+    from solps_helpers import read_ifield, read_rfield
+
 onedrive_path = onedrive_path = str(os.getcwd()).split("OneDrive")[0] + "OneDrive"
 sys.path.append(os.path.join(onedrive_path, r"Project\python-packages\gridtools"))
 sys.path.append(os.path.join(onedrive_path, r"Project\python-packages\sdtools"))
@@ -198,9 +203,119 @@ class SOLPScase():
         # First SOL rings
         for name in ["outer_sol", "outer_lower_sol", "outer_upper_sol", "inner_sol", "inner_lower_sol", "inner_upper_sol"]:
             s[name] = self.make_custom_sol_ring(name, i = 0)
+
+        self.read_b2fgmtry()
             
         self.get_species()
         self.derive_data()
+
+    def read_b2fgmtry(self, path = None, verbose = False, strict = False):
+        """
+        Read b2fgmtry and merge supplemental geometry data into self.g.
+
+        This preserves the existing geometry fields already initialised from
+        balance.nc and only adds fields that are not present yet. Guard cells
+        are kept intact so the extra topology arrays remain consistent with the
+        rest of SOLPScase.
+
+        Parameters
+        ----------
+        path : str or None
+            Explicit path to a b2fgmtry file. If omitted, search in the case
+            directory and then in ../baserun.
+        verbose : bool
+            If True, print the path that was loaded.
+        strict : bool
+            If True, raise FileNotFoundError when no b2fgmtry file is found.
+
+        Returns
+        -------
+        dict
+            Mapping of the fields that were newly added to self.g.
+
+        Based on code from Wouter Dekeyser (2016) and Matteo Moscheni (2022)
+        """
+
+        candidates = []
+        if path is not None:
+            candidates.append(path)
+        else:
+            candidates.append(os.path.join(self.path, "b2fgmtry"))
+            candidates.append(os.path.join(self.path, "../baserun/b2fgmtry"))
+
+        gmtry_path = next((candidate for candidate in candidates if os.path.exists(candidate)), None)
+        if gmtry_path is None:
+            if strict:
+                raise FileNotFoundError(f"b2fgmtry not found in {candidates}")
+            return {}
+
+        with open(gmtry_path, "r") as fid:
+            version = fid.readline()[7:17]
+            dim = read_ifield(fid, "nx,ny", [2])
+            nx = int(dim[0])
+            ny = int(dim[1])
+
+            qcdim = [nx + 2, ny + 2]
+            if version >= "03.001.000":
+                qcdim = [nx + 2, ny + 2, 2]
+
+            specs = [
+                ("isymm", read_ifield, 1),
+                ("crx", read_rfield, [nx + 2, ny + 2, 4]),
+                ("cry", read_rfield, [nx + 2, ny + 2, 4]),
+                ("fpsi", read_rfield, [nx + 2, ny + 2, 4]),
+                ("ffbz", read_rfield, [nx + 2, ny + 2, 4]),
+                ("bb", read_rfield, [nx + 2, ny + 2, 4]),
+                ("vol", read_rfield, [nx + 2, ny + 2]),
+                ("hx", read_rfield, [nx + 2, ny + 2]),
+                ("hy", read_rfield, [nx + 2, ny + 2]),
+                ("qz", read_rfield, [nx + 2, ny + 2, 2]),
+                ("qc", read_rfield, qcdim),
+                ("gs", read_rfield, [nx + 2, ny + 2, 3]),
+                ("nlreg", read_ifield, 1),
+                ("nlxlo", read_ifield, None),
+                ("nlxhi", read_ifield, None),
+                ("nlylo", read_ifield, None),
+                ("nlyhi", read_ifield, None),
+                ("nlloc", read_ifield, None),
+                ("nncut", read_ifield, 1),
+                ("leftcut", read_ifield, None),
+                ("rightcut", read_ifield, None),
+                ("topcut", read_ifield, None),
+                ("bottomcut", read_ifield, None),
+                ("leftix", read_ifield, [nx + 2, ny + 2]),
+                ("rightix", read_ifield, [nx + 2, ny + 2]),
+                ("topix", read_ifield, [nx + 2, ny + 2]),
+                ("bottomix", read_ifield, [nx + 2, ny + 2]),
+                ("leftiy", read_ifield, [nx + 2, ny + 2]),
+                ("rightiy", read_ifield, [nx + 2, ny + 2]),
+                ("topiy", read_ifield, [nx + 2, ny + 2]),
+                ("bottomiy", read_ifield, [nx + 2, ny + 2]),
+                ("region", read_ifield, [nx + 2, ny + 2, 3]),
+                ("nnreg", read_ifield, 3),
+                ("resignore", read_ifield, [nx + 2, ny + 2, 2]),
+                ("periodic_bc", read_ifield, 1),
+                ("pbs", read_rfield, [nx + 2, ny + 2, 2]),
+                ("parg", read_rfield, 100),
+            ]
+
+            gmtry = {"nx": nx, "ny": ny}
+            for fieldname, reader, dims in specs:
+                if dims is None:
+                    source = gmtry["nlreg"] if fieldname.startswith("nl") else gmtry["nncut"]
+                    dims = int(np.asarray(source).squeeze())
+                gmtry[fieldname] = reader(fid, fieldname, dims)
+
+        added_fields = {}
+        for key, value in gmtry.items():
+            if key not in self.g:
+                self.g[key] = value
+                added_fields[key] = value
+
+        if verbose:
+            print(f"Loaded b2fgmtry from {gmtry_path}")
+
+        return added_fields
         
     def get_species(self):
         """

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -964,7 +964,13 @@ class SOLPScase():
         
         return df
 
-    def _interpolate_exact_sol_ring(self, params, region, sepdist):
+    def _interpolate_exact_sol_ring(
+            self, 
+            params, 
+            region,
+            sepdist,
+            radial_start_region=None, 
+            debug = False):
         """
         Returns poloidal data radially interpolated to an exact separatrix distance.
         Uses the midplane radial profile to determine the target flux surface,
@@ -980,25 +986,37 @@ class SOLPScase():
         -------
         df : DataFrame with R, Z, hx, Btot, Bpol, vol and requested params
         """
-        if "outer" in region:
-            mp_region = "omp"
-        elif "inner" in region:
-            mp_region = "imp"
+
+        if "sol" in region:
+            if sepdist < 0:
+                raise ValueError("sepdist must be positive for SOL regions")
         else:
-            raise ValueError("Region must contain 'inner' or 'outer'")
+            if sepdist > 0:
+                raise ValueError("sepdist must be negative for core or PFR regions")
+        
+        ## Get radial slice to figure out field line starting point based on sepdist
+        if radial_start_region is None:
+            if "outer" in region:
+                radial_start_region = "omp"
+            elif "inner" in region:
+                radial_start_region = "imp"
+            else:
+                raise Exception(f"Radial start region must be provided for region {region}")
 
         # Get midplane radial profile to find fractional ring index for desired sepdist
-        radial_df = self.get_1d_radial_data(
-            [], region=mp_region, keep_geometry=True, guards=True
+        radial_slice = self.get_1d_radial_data(
+            ["fpsi"], region=radial_start_region, keep_geometry=True, guards=True
         )
 
+
         # Interpolate to find fractional ring index at the desired separatrix distance
-        y_frac = float(
+        psi = float(
             scipy.interpolate.interp1d(
-                radial_df["dist"].values,
-                np.arange(len(radial_df), dtype=float),
+                radial_slice["dist"].values,
+                radial_slice["fpsi"].values,
             )(sepdist)
         )
+
 
         # Get poloidal indices for the region (use sepadd=0 just to get the slice)
         test_selector = self.make_custom_sol_ring(region, i=0)
@@ -1013,7 +1031,7 @@ class SOLPScase():
         ny = self.g["ny"]
         y_indices = np.arange(ny, dtype=float)
 
-        geom_params = ["R", "Z", "hx", "Btot", "Bpol", "vol"]
+        geom_params = ["R", "Z", "hx", "Btot", "Bpol", "vol", "fpsi"]
         all_param_names = list(
             dict.fromkeys(geom_params + params)
         )  # deduplicate, preserve order
@@ -1041,16 +1059,29 @@ class SOLPScase():
             lookup[param_name] = arr
 
         # Interpolate across rings at each poloidal position
-        results = {p: np.empty(len(pol_indices)) for p in all_param_names}
+        
+        df = pd.DataFrame()
 
-        for i, pol_i in enumerate(pol_indices):
+        if debug:
+            fig, ax = plt.subplots(dpi = 150)
+            self.plot_2d("Te", ax = ax, grid_only = True)
+        for _, pol_i in enumerate(pol_indices):
+
+            radial = self.get_1d_radial_data(params = all_param_names, poloidal_index = pol_i)
+            
+            if debug:
+                ax.plot(radial["R"], radial["Z"], "o", markersize = 3, alpha = 0.5)
             for param_name in all_param_names:
-                radial_values = lookup[param_name][pol_i, :]
-                results[param_name][i] = float(
-                    scipy.interpolate.interp1d(y_indices, radial_values)(y_frac)
-                )
+                # radial_values = lookup[param_name][pol_i, :]
 
-        return pd.DataFrame(results)
+                df.loc[pol_i, param_name] = float(
+                    scipy.interpolate.interp1d(radial["fpsi"], radial[param_name])(psi)
+                )
+            
+            if debug:
+                ax.plot(df["R"], df["Z"], c = "deeppink")
+
+        return df
 
     def get_1d_poloidal_data_double(
         self,

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -806,42 +806,86 @@ class SOLPScase():
     def get_1d_radial_data(
         self,
         params,
-        region = "omp",
+        region = None,
+        poloidal_index = None,
         verbose = False,
         guards = False,
-        keep_geometry = False,
-        interpolate = True
+        keep_geometry = True,
+        interpolate_midplane = True
     ):
         """
-        Returns OMP, IMP or target data from the balance file
-        Note that the balance file shape is a transpose of the geometry shape (e.g. crx)
-        and contains guard cells.        
-        Target data is obtained from the guard cells which are very close to the wall.
+        Return a 1D radial profile at the inner/outer midplane or at a target.
+
+        The profile is assembled from SOLPS balance-file data, which already
+        includes guard cells and uses the same indexing convention as the rest
+        of ``SOLPScase``. For ``omp`` and ``imp`` the default behaviour is to
+        interpolate each ring onto ``Z = 0`` using a small poloidal stencil
+        around the midplane. For target regions, the value is taken from the
+        adjacent guard cell because that cell is the closest available point to
+        the wall.
+
+        Parameters
+        ----------
+        params : str or list[str]
+            Additional balance or geometry fields to include in the returned
+            profile.
+        region : str, default "omp"
+            One of ``"omp"``, ``"imp"``, ``"outer_lower_target"``,
+            ``"inner_lower_target"``, ``"outer_upper_target"`` or
+            ``"inner_upper_target"``.
+        verbose : bool, default False
+            Reserved for debugging output. Currently unused.
+        guards : bool, default False
+            If False, drop the first and last radial points before returning.
+            If True, keep the guard cells in the output.
+        keep_geometry : bool, default False
+            If False, drop geometry helper columns such as ``R``, ``hx``,
+            ``hy``, ``Btot`` and ``Bpol`` before returning.
+        interpolate_midplane : bool, default True
+            If True, interpolate OMP/IMP profiles to the exact midplane.
+            Target profiles are taken directly from the selected guard cells.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Radial profile containing the requested parameters together with
+            derived columns ``dist``, ``sep``, ``apar`` and ``vol``. The
+            ``dist`` coordinate is shifted so that zero corresponds to the
+            separatrix.
         """
         
         bal = self.bal
+
+        if poloidal_index is None and region is None:
+            raise ValueError("Must specify either poloidal_index or region")
+        if poloidal_index is not None and region is not None:
+            raise ValueError("Must specify either poloidal_index or region, not both")
 
         if type(params) == str:
             params = [params]
         
         # Poloidal selector
-        if any([region in name for name in [
-            "omp", "imp"]]):
+        if region is not None:
+            if any([region in name for name in [
+                "omp", "imp"]]):
 
-            p = self.s[region] 
-            selector = self.s[region]
+                p = self.s[region] 
+                selector = self.s[region]
+                
+            elif any([region in name for name in [
+                "outer_lower_target", "inner_lower_target",
+                "outer_upper_target", "inner_upper_target"]]):
+                
+                selector = self.s[region+"_guard"] # For targets take guard cell which is tiny & close to wall value
+                
+            else:
+                raise Exception(f"Unrecognised region: {region}")
             
-        elif any([region in name for name in [
-            "outer_lower_target", "inner_lower_target",
-            "outer_upper_target", "inner_upper_target"]]):
-            
-            selector = self.s[region+"_guard"] # For targets take guard cell which is tiny & close to wall value
-            
-        else:
-            raise Exception(f"Unrecognised region: {region}")
+        elif poloidal_index is not None:
+            selector = (poloidal_index, slice(None))
         
         ## Interpolate to Z = 0 for OMP and IMP
-        if (region == "omp" or region == "imp") and interpolate == True:
+        if (region == "omp" or region == "imp") and interpolate_midplane:
             ## Select a couple of cells on each side of the midplane
             if region == "omp":
                 pol_selector = slice(self.psel["omp"]-3, self.psel["omp"]+5)
@@ -864,6 +908,8 @@ class SOLPScase():
                 for param in ["Z", "R", "hx", "hy", "vol", "Btot", "Bpol"] + params:
                     if param in bal:
                         df_pol_slice[param] = bal[param][pol_selector, ring_id]
+                    elif param in self.g:
+                        df_pol_slice[param] = self.g[param][pol_selector, ring_id]
                     else:
                         print(f"Parameter {param} not found")
                     
@@ -877,7 +923,12 @@ class SOLPScase():
         else:
             df = pd.DataFrame()
             for param in ["hx", "hy", "R", "Z", "hx", "Btot", "Bpol", "vol"] + params:
-                df[param] = bal[param][selector]
+                if param in bal:
+                    df[param] = bal[param][selector]
+                elif param in self.g:
+                    df[param] = self.g[param][selector]
+                else:
+                    print(f"Parameter {param} not found")
                 
         
         # Interpolate between cells to get separatrix distance

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -822,6 +822,9 @@ class SOLPScase():
         adjacent guard cell because that cell is the closest available point to
         the wall.
 
+        TODO: Implement guard replacement. Here this is basically already done,
+        the guards are tiny and have the wall value for target stuff?
+
         Parameters
         ----------
         params : str or list[str]
@@ -874,14 +877,14 @@ class SOLPScase():
                 "outer_lower_target", "inner_lower_target",
                 "outer_upper_target", "inner_upper_target"]]):
                 
-                selector = self.s[region+"_guard"] # For targets take guard cell which is tiny & close to wall value
+                selector = self.s[region]
                 
             else:
                 raise Exception(f"Unrecognised region: {region}")
             
         elif poloidal_index is not None:
             selector = (poloidal_index, slice(None))
-        
+
         ## Interpolate to Z = 0 for OMP and IMP
         if (region == "omp" or region == "imp") and interpolate_midplane:
             ## Select a couple of cells on each side of the midplane

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -1112,9 +1112,12 @@ class SOLPScase():
         region="outer_lower_sol",
         sepadd=None,
         sepdist=None,
+        radial_start_region="auto",
         target_first=False,
         guards=False,
+        interpolate_midplane=True,
         interpolate_radial=True,
+        debug=False,
     ):
         """
         Returns field line data from the balance file
@@ -1141,6 +1144,9 @@ class SOLPScase():
         
         elif sepadd != None and sepdist != None:
             raise ValueError("Must use either index i or separatrix distance sepdist, not both")
+        
+        if region in ["pfr", "core"] and interpolate_midplane:
+            raise ValueError("Interpolate midplane should not be used for PFR or core regions!")
 
         # Radial interpolation path: interpolate across rings for exact sepdist
         if interpolate_radial:
@@ -1149,7 +1155,13 @@ class SOLPScase():
                     "sepdist must be specified if interpolate_radial is True"
                 )
 
-            df = self._interpolate_exact_sol_ring(params, region, sepdist)
+            df = self._interpolate_exact_sol_ring(
+                params,
+                region,
+                sepdist,
+                radial_start_region=radial_start_region,
+                debug=debug,
+            )
 
             hx = df["hx"].values
             Btot = df["Btot"].values
@@ -1173,9 +1185,6 @@ class SOLPScase():
                     - sepind
                 )
 
-            yind = self.g["sep"] + sepadd  # Ring index
-            omp = self.g["omp"]
-            imp = self.g["imp"]
 
             selector = self.make_custom_sol_ring(region, i=sepadd)
 

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -173,15 +173,16 @@ class SOLPScase():
         psel["outer_upper_target"] = upper_break+1
         psel["outer_lower_target"] = self.g["nx"] - 1
 
-        psel["inner_lower_target_guard"] = 0
+        psel["inner_lower_target_guard"] = 1
         psel["inner_upper_target_guard"] = upper_break -1
         psel["outer_upper_target_guard"] = upper_break
-        psel["outer_lower_target_guard"] = self.g["nx"]
+        psel["outer_lower_target_guard"] = self.g["nx"]-1
 
         psel["outer_upper_divertor"] = slice(self.g["upper_break"], self.g["rightcut"][1]+2)
         psel["inner_upper_divertor"] = slice(self.g["leftcut"][1]-2, self.g["upper_break"])
         psel["outer_lower_divertor"] = slice(self.g["rightcut"][0]+2, self.g["nx"])
         psel["inner_lower_divertor"] = slice(0, self.g["leftcut"][0]+2)
+
         # psel["upper_pfr"] = np.r_[psel["inner_upper_divertor"], psel["outer_upper_divertor"]]
         psel["upper_pfr"] = np.r_[psel["outer_upper_divertor"], psel["inner_upper_divertor"]]
         psel["lower_pfr"] = np.r_[psel["inner_lower_divertor"], psel["outer_lower_divertor"]]
@@ -193,11 +194,19 @@ class SOLPScase():
 
         # These are the poloidal selections used to construct custom rings.
         psel["outer_sol"] = slice(self.g["upper_break"], None)
-        psel["outer_lower_sol"] = slice(self.g["omp"], None)
-        psel["outer_upper_sol"] = slice(self.g["upper_break"], self.g["omp"] + 2)
-        psel["inner_sol"] = slice(1, self.g["upper_break"])
-        psel["inner_lower_sol"] = slice(1, self.g["imp"] + 1)
-        psel["inner_upper_sol"] = slice(self.g["imp"] - 1, self.g["upper_break"])
+        psel["inner_sol"] = slice(0, self.g["upper_break"])
+
+        psel["outer_lower_sol"] = slice(self.g["omp"]+1, None)
+        psel["outer_upper_sol"] = slice(self.g["upper_break"], self.g["omp"] + 1)
+
+        psel["outer_lower_sol_extra"] = slice(self.g["omp"], None)
+        psel["outer_upper_sol_extra"] = slice(self.g["upper_break"], self.g["omp"] + 2)
+
+        psel["inner_lower_sol"] = slice(0, self.g["imp"])
+        psel["inner_upper_sol"] = slice(self.g["imp"], self.g["upper_break"])
+
+        psel["inner_lower_sol_extra"] = slice(0, self.g["imp"] + 1)
+        psel["inner_upper_sol_extra"] = slice(self.g["imp"] - 1, self.g["upper_break"])
         
         psel["inner_core"] = slice(self.g["leftcut"][0] + 2, self.g["leftcut"][1] - 2)
         psel["outer_core"] = slice(self.g["rightcut"][1] + 2, self.g["rightcut"][0] + 2)
@@ -1212,6 +1221,9 @@ class SOLPScase():
         
         if "divertor" in region and interpolate_midplane:
             raise ValueError("Interpolate midplane = true should not be used for divertor regions!")
+        
+        if "extra" not in region and interpolate_midplane:
+            raise ValueError("Region doesn't go beyond the midplane, can't interpolate to midplane! Try regions with suffix _extra")
 
         if any([x in region for x in ["pfr", "core"]]) and interpolate_midplane:
             raise ValueError("Interpolate midplane = true should not be used for PFR or core regions!")
@@ -1234,6 +1246,11 @@ class SOLPScase():
             elif region == "upper_pfr":
                 radial_start_region = "outer_upper_target"
 
+        if debug:
+            print(f"Region: {region}")
+            print(f"Sepdist: {sepdist}")
+            print(f"Sepadd: {sepadd}")
+            print(f"Radial start region: {radial_start_region}")
         # Radial interpolation path: interpolate across rings for exact sepdist
         if interpolate_radial:
             if sepdist is None:
@@ -1342,7 +1359,7 @@ class SOLPScase():
         
         if "sol" in region:
             ## Value of X-point column will be 1 in the cell just downstream of X-point
-            Xpoint_index = df.index[-self.psel[f"{region.replace("_sol", "")}_xpoint_fromtarget"]+1]
+            Xpoint_index = df.index[-self.psel[region.split("_sol")[0]+"_xpoint_fromtarget"]+1]
             
             df.loc[:Xpoint_index, "region"] = "upstream"
             df.loc[Xpoint_index:, "region"] = "divertor"
@@ -1459,7 +1476,7 @@ class SOLPScase():
 
         # return xpoints
     
-    def plot_selection(self, sel, ax = None, **kwargs):
+    def plot_selection(self, sel, ax = None, title = None, **kwargs):
         """
         Plots scatter of selected points according to the tuple sel
         which contains slices in (X, Y)
@@ -1485,12 +1502,17 @@ class SOLPScase():
         if ax == None:
             fig, ax = plt.subplots(dpi = dpi)
 
+        
+
         self.plot_2d("", ax = ax, data = data, cmap = mpl.colors.ListedColormap(["lightgrey", "limegreen"]),
              antialias = True, 
              cbar = False,
              **plot_kwargs)
         
         ax.scatter(self.g["R"][sel], self.g["Z"][sel], c = "deeppink", s = 3)
+
+        if title:
+            ax.set_title(title)
         
     def extract_cooling_curve(self, species, region, sepadd, order = 10, 
                               plot = False, cz_effect = False,

--- a/code_comparison/solps_pp.py
+++ b/code_comparison/solps_pp.py
@@ -70,8 +70,19 @@ class SOLPScase():
         You can get the species indeces from the string matrix "species" 
         (for Ryoko's case I think it's 4:21 for the neon ions but do check)
         numbers are in W, so divide by "vol" to get W/m3
+
+        GEOMETRY NOTES
+        -----------
+        psi is not the same COCOS and format as Hermes-3:
+        - Hermes-3 has revesed Bpol and Btor which means the psi gradient is reversed
+        - There is also a 2pi factor in SOLPS due to different cocos
+        - There is also a different offset
+        - The above shouldn't matter, so below we align the two
+
+        There is a routine for this in sdtools.code_comparison.grid_interp.TransplantFromSOLPS.align_psi
         
         Balance file variables
+        ------------
         
         FLUXES
         ------------
@@ -311,6 +322,10 @@ class SOLPScase():
             if key not in self.g:
                 self.g[key] = value
                 added_fields[key] = value
+
+
+        # Get psi at cell centres instead of corners
+        self.g["fpsi"] = self.g["fpsi"].mean(axis=2).squeeze()
 
         if verbose:
             print(f"Loaded b2fgmtry from {gmtry_path}")

--- a/general/amjuel/amjuel_reader.py
+++ b/general/amjuel/amjuel_reader.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import numpy as np
+
+
+_DFLOAT_PATTERN = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:D\s*[+-]?\s*\d+)"
+_COEFF_ROW_RE = re.compile(
+    rf"^\s*(?P<t_index>\d+)\s+"
+    rf"(?P<v0>{_DFLOAT_PATTERN})\s+"
+    rf"(?P<v1>{_DFLOAT_PATTERN})\s+"
+    rf"(?P<v2>{_DFLOAT_PATTERN})\s*$"
+)
+_SECTION_RE = re.compile(r"\\section\{(?P<header>.*?)\}(?P<body>.*?)(?=(?:\\section\{|\Z))", re.S)
+_SUBSECTION_RE = re.compile(
+    r"\\subsection\{\s*Reaction\s+(?P<reaction>\S+)(?P<header>.*?)\}(?P<body>.*?)(?=(?:\\subsection\{|\\section\{|\Z))",
+    re.S,
+)
+_BOUND_RE = re.compile(
+    rf"(?P<key>[A-Z]\d(?:MIN|MAX))\s*=\s*(?P<value>{_DFLOAT_PATTERN})\s*(?P<unit>[^\n]*)"
+)
+
+
+def _parse_d_float(value: str) -> float:
+    """Convert a Fortran-style float string.
+
+    Inputs:
+        value: String containing a number that may use D exponents.
+
+    Returns:
+        Parsed floating-point value.
+    """
+    value = value.replace("D", "E")
+    value = re.sub(
+        r"E\s*([+-]?)\s*(\d+)",
+        lambda match: f"E{match.group(1) or '+'}{match.group(2)}",
+        value,
+    )
+    return float(value)
+
+
+def _positive_array(name: str, value: float | np.ndarray) -> np.ndarray:
+    """Convert an input to a positive float array.
+
+    Inputs:
+        name: Label used in the error message.
+        value: Scalar or array to validate.
+
+    Returns:
+        Numpy array of positive float values.
+    """
+    value = np.asarray(value, dtype=float)
+    if np.any(value <= 0.0):
+        raise ValueError(f"{name} must be strictly positive because AMJUEL uses logarithms.")
+    return value
+
+
+def extract_fit(name: str, tex_path: str | Path) -> dict[str, object]:
+    """Extract one AMJUEL fit block from the tex file.
+
+    Inputs:
+        name: Fit name such as "H.4 2.1.5".
+        tex_path: Path to the AMJUEL tex source.
+
+    Returns:
+        Dictionary containing metadata, coefficients, and fit bounds.
+    """
+    name = " ".join(name.split())
+    name_match = re.fullmatch(r"(H\.\d+)\s+(\S+)", name)
+    if name_match is None:
+        raise ValueError(
+            "AMJUEL names must look like 'H.4 2.1.5' or 'H.10 2.1.5'."
+        )
+    family, reaction = name_match.groups()
+    text = Path(tex_path).read_text(encoding="utf-8")
+
+    for section_match in _SECTION_RE.finditer(text):
+        section_header = re.sub(r"\\cite\{[^}]*\}", "", section_match.group("header"))
+        section_header = " ".join(section_header.replace("\\\\", " ").split())
+        family_match = re.match(r"(H\.\d+)\s*:", section_header)
+        if family_match is None or family_match.group(1) != family:
+            continue
+
+        compact_header = section_header.replace(" ", "")
+        if "(E,T)" in compact_header:
+            second_param = "E"
+        elif re.search(r"\(n[^,]*,T", compact_header):
+            second_param = "Ne"
+        else:
+            raise ValueError(f"Could not infer the second AMJUEL parameter from section header: {section_header}")
+
+        for subsection_match in _SUBSECTION_RE.finditer(section_match.group("body")):
+            if subsection_match.group("reaction") != reaction:
+                continue
+
+            subsection_body = subsection_match.group("body")
+            marker = "\\begin{small}\\begin{verbatim}"
+            if marker not in subsection_body:
+                continue
+
+            description, coeff_text = subsection_body.split(marker, maxsplit=1)
+            coeff_text, _ = coeff_text.split("\\end{verbatim}", maxsplit=1)
+            description = re.sub(r"\\cite\{[^}]*\}", "", description)
+            description = " ".join(description.replace("\\\\", " ").split())
+
+            coeffs = np.zeros((9, 9), dtype=float)
+            bounds: dict[str, float] = {}
+            bound_units: dict[str, str] = {}
+            current_e_indices: list[int] | None = None
+            parsed_rows = 0
+
+            for line in coeff_text.splitlines():
+                if "E-Index:" in line:
+                    current_e_indices = [int(index) for index in re.findall(r"\d+", line)]
+                    continue
+
+                bound_match = _BOUND_RE.match(line.strip())
+                if bound_match is not None:
+                    key = bound_match.group("key")
+                    bounds[key] = _parse_d_float(bound_match.group("value"))
+                    bound_units[key] = " ".join(bound_match.group("unit").split())
+                    continue
+
+                row_match = _COEFF_ROW_RE.match(line)
+                if row_match is None or current_e_indices is None:
+                    continue
+
+                row_values = [
+                    _parse_d_float(row_match.group("v0")),
+                    _parse_d_float(row_match.group("v1")),
+                    _parse_d_float(row_match.group("v2")),
+                ]
+                t_index = int(row_match.group("t_index"))
+                for e_index, value in zip(current_e_indices, row_values, strict=True):
+                    coeffs[t_index, e_index] = value
+                parsed_rows += 1
+
+            if parsed_rows != 27:
+                raise ValueError(f"Expected 27 coefficient rows, found {parsed_rows}.")
+
+            return {
+                "name": name,
+                "family": family,
+                "reaction": reaction,
+                "description": description,
+                "second_param": second_param,
+                "coeffs": coeffs,
+                "bounds": bounds,
+                "bound_units": bound_units,
+            }
+
+        raise KeyError(f"Reaction {name} was not found in {tex_path}.")
+
+    raise KeyError(f"Family {family} was not found in {tex_path}.")
+
+
+def evaluate_from_coefficients(
+    coeffs: np.ndarray,
+    Te: float | np.ndarray,
+    second_value: float | np.ndarray | None = None,
+    *,
+    second_param: str = "Ne",
+    mode: str = "default",
+    pop_ratio: bool = False,
+) -> float | np.ndarray:
+    """Evaluate a 2D AMJUEL polynomial from a coefficient table.
+
+    Inputs:
+        coeffs: 9x9 AMJUEL coefficient array.
+        Te: Electron temperature in eV.
+        second_value: Density or energy axis value for the fit.
+        second_param: Name of the second axis, usually "Ne" or "E".
+        mode: Evaluation mode, either "default" or "coronal".
+        pop_ratio: If true, skip the final 1e-6 conversion.
+
+    Returns:
+        Scalar or array of evaluated rate values.
+    """
+    if mode not in {"default", "coronal"}:
+        raise ValueError("mode must be 'default' or 'coronal'.")
+
+    log_te = np.log(_positive_array("Te", Te))
+
+    if mode == "coronal":
+        log_rate = np.zeros_like(log_te, dtype=float)
+        for t_index in range(coeffs.shape[0]):
+            log_rate += coeffs[t_index, 0] * np.power(log_te, t_index)
+    else:
+        if second_value is None:
+            raise ValueError("A second parameter value is required in default mode.")
+
+        second_array = _positive_array(second_param, second_value)
+        log_te, second_array = np.broadcast_arrays(log_te, second_array)
+
+        if second_param == "Ne":
+            second_array = second_array * 1.0e-14
+
+        log_second = np.log(second_array)
+        log_rate = np.zeros_like(log_te, dtype=float)
+        for t_index in range(coeffs.shape[0]):
+            te_term = np.power(log_te, t_index)
+            for e_index in range(coeffs.shape[1]):
+                log_rate += coeffs[t_index, e_index] * te_term * np.power(log_second, e_index)
+
+    rate = np.exp(log_rate)
+    if not pop_ratio:
+        rate = rate * 1.0e-6
+
+    return float(rate) if np.ndim(rate) == 0 else rate
+
+
+def amjuel_2d(
+    name: str,
+    Te: float | np.ndarray,
+    Ne: float | np.ndarray | None = None,
+    *,
+    E: float | np.ndarray | None = None,
+    tex_path: str | Path,
+    mode: str = "default",
+    pop_ratio: bool = False,
+) -> float | np.ndarray:
+    """Load a fit from tex and evaluate it for Te and Ne or E.
+
+    Inputs:
+        name: Fit name such as "H.4 2.1.5".
+        Te: Electron temperature in eV.
+        Ne: Electron density in m^-3 for density-based fits.
+        E: Beam or process energy in eV for energy-based fits.
+        tex_path: Path to the AMJUEL tex source.
+        mode: Evaluation mode, either "default" or "coronal".
+        pop_ratio: If true, skip the final 1e-6 conversion.
+
+    Returns:
+        Scalar or array of evaluated rate values.
+    """
+    fit = extract_fit(name, tex_path=tex_path)
+    second_param = fit["second_param"]
+    coeffs = fit["coeffs"]
+
+    if second_param == "Ne":
+        if E is not None:
+            raise ValueError(f"{fit['name']} is density-based. Pass Ne, not E.")
+        return evaluate_from_coefficients(
+            coeffs,
+            Te,
+            None if mode == "coronal" else Ne,
+            second_param="Ne",
+            mode=mode,
+            pop_ratio=pop_ratio,
+        )
+
+    if Ne is not None:
+        raise ValueError(f"{fit['name']} is energy-based. Pass E, not Ne.")
+    return evaluate_from_coefficients(
+        coeffs,
+        Te,
+        E,
+        second_param="E",
+        mode=mode,
+        pop_ratio=pop_ratio,
+    )
+
+
+evaluate_rate = amjuel_2d

--- a/hermes3/accessors.py
+++ b/hermes3/accessors.py
@@ -377,6 +377,14 @@ def _select_region(ds, name):
     slices["upper_pfr"] = (slice(0, ixseps1), slice(j2_1g + 1, j1_2g + 1))
 
     if "single-null" not in m["topology"]:
+        slices["inner_upper_pfr"] = (
+            slice(0, ixseps1),
+            slice(j2_1g + 1, ny_inner + MYG),
+        )
+        slices["outer_upper_pfr"] = (
+            slice(0, ixseps1),
+            slice(ny_inner + MYG * 3, j1_2g + 1),
+        )
         slices["inner_upper_pfr_edge"] = (
             slice(MXG, MXG + 1),
             slice(j2_1g + 1, ny_inner),
@@ -471,7 +479,7 @@ def _select_custom_core_ring(ds, i):
     return ds.isel(x=selection[0], theta=selection[1])
 
 
-def _select_custom_sol_ring(ds, region, sepadd = None, sepdist = None):
+def _select_custom_sol_ring(ds, region, sepadd = None, sepdist = None, radial_start_region="auto"):
     """
     Creates custom SOL ring slice beyond the separatrix. 
     Can use SOL ring index sepadd OR radial distance from the separatrix sepdist.
@@ -483,13 +491,23 @@ def _select_custom_sol_ring(ds, region, sepadd = None, sepdist = None):
         region : inner_sol, inner_lower_sol, inner_upper_sol, outer_sol, outer_lower_sol, outer_upper_sol
     """
 
-    if region not in ["inner_sol", "inner_lower_sol", "inner_upper_sol", "outer_sol", "outer_lower_sol", "outer_upper_sol"]:
-        raise ValueError("Region must be one of: inner_sol, inner_lower_sol, inner_upper_sol, outer_sol, outer_lower_sol, outer_upper_sol")
-
-    if "inner" in region:
-        midplane_region = "imp"
-    elif "outer" in region:
-        midplane_region = "omp"
+    if radial_start_region == "auto":
+        if region == "outer_lower_pfr":
+            radial_start_region = "outer_lower_target"
+        elif region == "outer_upper_pfr":
+            radial_start_region = "outer_upper_target"
+        elif region == "inner_lower_pfr":
+            radial_start_region = "inner_lower_target"
+        elif region == "inner_upper_pfr":
+            radial_start_region = "inner_upper_target"
+        elif "outer" in region:
+            radial_start_region = "omp"
+        elif "inner" in region:
+            radial_start_region = "imp"
+        elif region == "lower_pfr":
+            radial_start_region = "outer_lower_target"
+        elif region == "upper_pfr":
+            radial_start_region = "outer_upper_target"
     
     m = ds.metadata
     
@@ -499,18 +517,19 @@ def _select_custom_sol_ring(ds, region, sepadd = None, sepdist = None):
     elif sepadd != None and sepdist != None:
         raise ValueError("Must use either index i or separatrix distance sepdist, not both")
     
-    # FIXME: This currently assumes that OMP distances are the same as IMP.
     elif sepdist != None:
-        df = get_1d_radial_data(ds, [], midplane_region)
+        df = get_1d_radial_data(ds, [], radial_start_region)
         sepind = df[df["sep"] == 1].index[0]
         sepadd = df.loc[(df["Srad"] - sepdist).abs().idxmin()].name - sepind
         
     radial_index = sepadd + m["ixseps1"]
 
     # "extra" has an extra point before the midplane so you can interpolate to the midplane 
-    selection = (radial_index, ds.metadata["poloidal_slices"][f"{region}_extra"])
+    if "sol" in region and "extra" not in region:
+        region = f"{region}_extra"
 
-    
+    selection = (radial_index, ds.metadata["poloidal_slices"][region])
+
     return ds.isel(x = selection[0], theta = selection[1])
 
 

--- a/hermes3/accessors.py
+++ b/hermes3/accessors.py
@@ -480,8 +480,11 @@ def _select_custom_sol_ring(ds, region, sepadd = None, sepdist = None):
     Parameters:
         i : radial index
         sepdist : radial distance from the separatrix
-        region : inner, inner_lower, inner_upper, outer, outer_lower, outer_upper
+        region : inner_sol, inner_lower_sol, inner_upper_sol, outer_sol, outer_lower_sol, outer_upper_sol
     """
+
+    if region not in ["inner_sol", "inner_lower_sol", "inner_upper_sol", "outer_sol", "outer_lower_sol", "outer_upper_sol"]:
+        raise ValueError("Region must be one of: inner_sol, inner_lower_sol, inner_upper_sol, outer_sol, outer_lower_sol, outer_upper_sol")
 
     if "inner" in region:
         midplane_region = "imp"
@@ -504,7 +507,8 @@ def _select_custom_sol_ring(ds, region, sepadd = None, sepdist = None):
         
     radial_index = sepadd + m["ixseps1"]
 
-    selection = (radial_index, slice(*_get_poloidal_range(ds, region)))
+    # "extra" has an extra point before the midplane so you can interpolate to the midplane 
+    selection = (radial_index, ds.metadata["poloidal_slices"][f"{region}_extra"])
 
     
     return ds.isel(x = selection[0], theta = selection[1])

--- a/hermes3/accessors.py
+++ b/hermes3/accessors.py
@@ -23,19 +23,20 @@ class HermesDataArrayAccessor(BoutDataArrayAccessor):
         return _select_custom_core_ring(self.data, i)
 
     def clean_guards(self):
-        """
-        Set guard cell values to np.nan
-        Implemented for both 
-        """
-        xguards = _select_region(self.data, "xguards")
-        ds = self.data.copy()
-        ds[{"x": xguards[0], "theta": xguards[1]}] = np.nan
+        raise Exception("sdtools clean_guards is deprecated, use xHermes clear_guards instead")
+        # """
+        # Set guard cell values to np.nan
+        # Implemented for both 
+        # """
+        # xguards = _select_region(self.data, "xguards")
+        # ds = self.data.copy()
+        # ds[{"x": xguards[0], "theta": xguards[1]}] = np.nan
         
-        # Clear target guards if they are there
-        if self.data.metadata["MYG"] > 0:
-            for name in self.data.metadata["targets"]:
-                yguards = _select_region(self.data, f"{name}_target_guards")
-                ds[{"x": yguards[0], "theta": yguards[1]}] = np.nan
+        # # Clear target guards if they are there
+        # if self.data.metadata["MYG"] > 0:
+        #     for name in self.data.metadata["targets"]:
+        #         yguards = _select_region(self.data, f"{name}_target_guards")
+        #         ds[{"x": yguards[0], "theta": yguards[1]}] = np.nan
             
         return ds
     def guard_replace_1d(self):

--- a/hermes3/accessors.py
+++ b/hermes3/accessors.py
@@ -3,6 +3,7 @@ from xbout import BoutDatasetAccessor, BoutDataArrayAccessor
 from hermes3.plotting import *
 from hermes3.front_tracking import _get_front_position
 from hermes3.selectors import get_1d_radial_data
+import xhermes
 import numpy as np
 
 
@@ -492,6 +493,11 @@ def _select_custom_sol_ring(ds, region, sepadd = None, sepdist = None, radial_st
         region : inner_sol, inner_lower_sol, inner_upper_sol, outer_sol, outer_lower_sol, outer_upper_sol
     """
 
+    if region == "all":
+        region = "sol"
+    elif region in ["inner", "outer", "inner_lower", "inner_upper", "outer_lower", "outer_upper"]:
+        region = f"{region}_sol"
+
     if radial_start_region == "auto":
         if region == "outer_lower_pfr":
             radial_start_region = "outer_lower_target"
@@ -529,7 +535,10 @@ def _select_custom_sol_ring(ds, region, sepadd = None, sepdist = None, radial_st
     if "sol" in region and "extra" not in region:
         region = f"{region}_extra"
 
-    selection = (radial_index, ds.metadata["poloidal_slices"][region])
+    if "sol" in region and "extra" not in region:
+        region = f"{region}_extra"
+
+    selection = (radial_index, xhermes.selector_poloidal(ds, region))
 
     return ds.isel(x = selection[0], theta = selection[1])
 

--- a/hermes3/accessors.py
+++ b/hermes3/accessors.py
@@ -2,7 +2,7 @@ from xarray import register_dataset_accessor, register_dataarray_accessor
 from xbout import BoutDatasetAccessor, BoutDataArrayAccessor
 from hermes3.plotting import *
 from hermes3.front_tracking import _get_front_position
-from hermes3.selectors import get_1d_radial_data, _get_poloidal_range
+from hermes3.selectors import get_1d_radial_data
 import numpy as np
 
 

--- a/hermes3/front_tracking.py
+++ b/hermes3/front_tracking.py
@@ -13,7 +13,7 @@ def _get_front_position(ds, more_fronts = False):
     if "t" not in ds.dims:
         raise Exception("Dataset must contain more than one timestep")
     fl = ds.hermesm.select_custom_sol_ring("outer_lower", sepadd = 0).squeeze()
-    dist = np.cumsum(fl["dl"]).values
+    dist = np.cumsum(fl["dpol"]).values
     dist_from_target = dist[-1] - dist
 
     df = pd.DataFrame()

--- a/hermes3/load.py
+++ b/hermes3/load.py
@@ -178,9 +178,8 @@ class Case:
             self.derive_vars()
         
         if self.is_2d is True:
-            self.ds = self.ds.hermes.extract_2d_tokamak_geometry()
+            pass
         else:
-            self.ds = self.ds.hermes.extract_1d_tokamak_geometry()
             if guard_replace:
                 print("Replacing guard cells")
                 self.ds = self.ds.hermes.guard_replace_1d()

--- a/hermes3/load.py
+++ b/hermes3/load.py
@@ -982,146 +982,24 @@ class Case:
         return self.ds.isel(x = selection[0], theta = selection[1])
     
     def select_custom_core_ring(self, i):
-            """
-            Creates custom SOL ring slice within the core.
-            i = 0 is at first domain cell.
-            i = -2 is at first inner guard cell.
-            i = ixseps - MXG is the separatrix.
-            """
-            
-            if i > self.ixseps1 - self.MXG:
-                raise Exception("i is too large!")
-            
-            selection = (slice(0+self.MXG+i,1+self.MXG+i), np.r_[slice(self.j1_2g + 1, self.j2_2g + 1), slice(self.j1_1g + 1, self.j2_1g + 1)])
-            
-            return self.ds.isel(x = selection[0], theta = selection[1])
+            return self.ds.hermesm.select_custom_core_ring(i)
         
         
         
         
         
-    def select_custom_sol_ring(self, i, region):
-            """
-            Creates custom SOL ring slice beyond the separatrix.
-            args[0] = i = index of SOL ring (0 is separatrix, 1 is first SOL ring)
-            args[1] = region = all, inner, inner_lower, inner_upper, outer, outer_lower, outer_upper
-            
-            NOTE: INDEX HERE IS THE ACTUAL INDEX AS OPPOSED TO THE CUSTOM CORE RING
-            
-            TODO: CHECK THE OFFSETS ON X AXIS, THEY ARE POTENTIALLY WRONG
-            """
-            
-            # if i < self.ixseps1 - self.MXG*2 :
-            #     raise Exception("i is too small!")
-            if i > self.nx - self.MXG*2 :
-                raise Exception("i is too large!")
-            
-            if self.ds.metadata["topology"] == "connected-double-null":
-                
-                outer_midplane_a = int((self.j2_2g - self.j1_2g) / 2) + self.j1_2g
-                outer_midplane_b = int((self.j2_2g - self.j1_2g) / 2) + self.j1_2g + 1     
-                inner_midplane_a = int((self.j2_1g - self.j1_1g) / 2) + self.j1_1g 
-                inner_midplane_b = int((self.j2_1g - self.j1_1g) / 2) + self.j1_1g + 1               
-                
-                
-                
-                if region == "all":
-                    selection = (slice(i+1,i+2), np.r_[slice(0+self.MYG, self.j2_2g + 1), slice(self.j1_1g + 1, self.nyg - self.MYG)])
-                
-                if region == "inner":
-                    selection = (slice(i+1,i+2), slice(0+self.MYG, self.ny_inner + self.MYG))
-                if region == "inner_lower":
-                    selection = (slice(i+1,i+2), slice(0+self.MYG, inner_midplane_a +1))
-                if region == "inner_upper":
-                    selection = (slice(i+1,i+2), slice(inner_midplane_b, self.ny_inner + self.MYG))
-                
-                if region == "outer":
-                    selection = (slice(i+1,i+2), slice(self.ny_inner + self.MYG*3, self.nyg - self.MYG))
-                if region == "outer_lower":
-                    selection = (slice(i+1,i+2), slice(outer_midplane_b, self.nyg - self.MYG))
-                if region == "outer_upper":
-                    selection = (slice(i+1,i+2), slice(self.ny_inner + self.MYG*3, outer_midplane_a+1))
-                    
-            elif self.ds.metadata["topology"] == "single-null":
-                
-                if region == "all":
-                    selection = (slice(i+0,i+1), slice(0+self.MYG, self.nyg - self.MYG))
-            
-            return self.ds.isel(x = selection[0], theta = selection[1])
+    def select_custom_sol_ring(self, region, sepadd = None, sepdist = None, radial_start_region="auto"):
+            return self.ds.hermesm.select_custom_sol_ring(
+                region,
+                sepadd = sepadd,
+                sepdist = sepdist,
+                radial_start_region = radial_start_region,
+            )
 
 
 
     def select_region(self, name):
-        """
-        DOUBLE NULL ONLY
-        Pass this tuple to a field of any parameter spanning the grid
-        to select points of the appropriate region.
-        Each slice is a tuple: (x slice, y slice)
-        Use it as: selected_array = array[slice] where slice = (x selection, y selection) = output from this method.
-        Returns sliced xarray dataset
-        NOTE: Everything is optimised for reading the case with guard cells 
-        """
-
-        slices = dict()
-
-        slices["all"] = (slice(None,None), slice(None,None))
-        slices["all_noguards"] = (slice(self.MXG,-self.MXG), np.r_[slice(self.MYG,self.ny_inner-self.MYG*2), slice(self.ny_inner+self.MYG*3, self.nyg - self.MYG)])
-
-        slices["core"] = (slice(0,self.ixseps1), np.r_[slice(self.j1_1g + 1, self.j2_1g+1), slice(self.j1_2g + 1, self.j2_2g + 1)])
-        slices["core_noguards"] = (slice(self.MXG,self.ixseps1), np.r_[slice(self.j1_1g + 1, self.j2_1g+1), slice(self.j1_2g + 1, self.j2_2g + 1)])
-        slices["sol"] = (slice(self.ixseps1, None), slice(0, self.nyg))
-        slices["sol_noguards"] = (slice(self.ixseps1, -self.MYG), np.r_[slice(self.MYG,self.ny_inner-self.MYG*2), slice(self.ny_inner+self.MYG*3, self.nyg - self.MYG)])
-
-        slices["outer_core_edge"] = (slice(0+self.MXG,1+self.MXG), slice(self.j1_2g + 1, self.j2_2g + 1))
-        slices["inner_core_edge"] = (slice(0+self.MXG,1+self.MXG), slice(self.j1_1g + 1, self.j2_1g + 1))
-        slices["core_edge"] = (slice(0+self.MXG,1+self.MXG), np.r_[slice(self.j1_2g + 1, self.j2_2g + 1), slice(self.j1_1g + 1, self.j2_1g + 1)])
-        
-        if self.MXG != 0:
-            
-            slices["outer_sol_edge"] = (slice(-1 - self.MXG, - self.MXG), slice(self.ny_inner+self.MYG*3, self.nyg - self.MYG))
-            slices["inner_sol_edge"] = (slice(-1 - self.MXG, - self.MXG), slice(self.MYG, self.ny_inner+self.MYG))
-            slices["sol_edge"] = (slice(-1 - self.MXG, - self.MXG), np.r_[slice(self.j1_1g + 1, self.j2_1g + 1), slice(self.ny_inner+self.MYG*3, self.nyg - self.MYG)])
-            
-        else:
-            
-            slices["outer_sol_edge"] = (slice(-1, None), slice(self.ny_inner+self.MYG*3, self.nyg - self.MYG))
-            slices["inner_sol_edge"] = (slice(-1, None), slice(self.MYG, self.ny_inner+self.MYG))
-            slices["sol_edge"] = (slice(-1 - self.MXG, - self.MXG), np.r_[slice(self.j1_1g + 1, self.j2_1g + 1), slice(self.ny_inner+self.MYG*3, self.nyg - self.MYG)])
-        
-        slices["inner_lower_target"] = (slice(None,None), slice(self.MYG, self.MYG + 1))
-        slices["inner_upper_target"] = (slice(None,None), slice(self.ny_inner+self.MYG -1, self.ny_inner+self.MYG))
-        slices["outer_upper_target"] = (slice(None,None), slice(self.ny_inner+self.MYG*3, self.ny_inner+self.MYG*3+1))
-        slices["outer_lower_target"] = (slice(None,None), slice(self.nyg-self.MYG-1, self.nyg - self.MYG))
-        
-        slices["inner_lower_target_guard"] = (slice(None,None), slice(self.MYG -1, self.MYG))
-        slices["inner_upper_target_guard"] = (slice(None,None), slice(self.ny_inner+self.MYG , self.ny_inner+self.MYG+1))
-        slices["outer_upper_target_guard"] = (slice(None,None), slice(self.ny_inner+self.MYG*3-1, self.ny_inner+self.MYG*3))
-        slices["outer_lower_target_guard"] = (slice(None,None), slice(self.nyg-self.MYG, self.nyg - self.MYG+1))
-        
-        slices["inner_lower_pfr"] = (slice(0, self.ixseps1), slice(None, self.j1_1g))
-        slices["outer_lower_pfr"] = (slice(0, self.ixseps1), slice(self.j2_2g+1, self.nyg))
-
-        slices["lower_pfr"] = (slice(0, self.ixseps1), np.r_[slice(None, self.j1_1g+1), slice(self.j2_2g+1, self.nyg)])
-        slices["upper_pfr"] = (slice(0, self.ixseps1), slice(self.j2_1g+1, self.j1_2g+1))
-        slices["pfr"] = (slice(0, self.ixseps1), np.r_[ 
-                                                        np.r_[slice(None, self.j1_1g+1), slice(self.j2_2g+1, self.nyg)], 
-                                                        slice(self.j2_1g+1, self.j1_2g+1)])
-        
-        slices["lower_pfr_edge"] = (slice(self.MXG, self.MXG+1), np.r_[slice(None, self.j1_1g+1), slice(self.j2_2g+1, self.nyg)])
-        slices["upper_pfr_edge"] = (slice(self.MXG, self.MXG+1), slice(self.j2_1g+1, self.j1_2g+1))
-        slices["pfr_edge"] = (slice(self.MXG, self.MXG+1), np.r_[
-                                                                    np.r_[slice(None, self.j1_1g+1), slice(self.j2_2g+1, self.nyg)],
-                                                                    slice(self.j2_1g+1, self.j1_2g+1)])
-        
-        slices["outer_midplane_a"] = (slice(None, None), int((self.j2_2g - self.j1_2g) / 2) + self.j1_2g)
-        slices["outer_midplane_b"] = (slice(None, None), int((self.j2_2g - self.j1_2g) / 2) + self.j1_2g + 1)
-
-        slices["inner_midplane_a"] = (slice(None, None), int((self.j2_1g - self.j1_1g) / 2) + self.j1_1g + 1)
-        slices["inner_midplane_b"] = (slice(None, None), int((self.j2_1g - self.j1_1g) / 2) + self.j1_1g)
-
-        selection = slices[name]
-        
-        return self.ds.isel(x = selection[0], theta = selection[1])
+        return self.ds.hermesm.select_region(name)
     
     def select_domain_boundary(self):
         """
@@ -1254,8 +1132,12 @@ class Case:
         m["j2_2g"] = m["j2_2"] + m["MYG"] * (num_targets - 1)
         
         # Separatrix index accounting for guard cells
-        m["ixseps1g"] = m["ixseps1"] - m["MXG"]
-        m["ixseps2g"] = m["ixseps2"] - m["MXG"]
+        if m["MXG"] == 0:
+            m["ixseps1g"] = m["ixseps1"] - 2
+            m["ixseps2g"] = m["ixseps2"] - 2
+        else:
+            m["ixseps1g"] = m["ixseps1"]
+            m["ixseps2g"] = m["ixseps2"]
         
         # Poloidal midplane indices
         m["omp_a"] = int((m["j2_2g"] - m["j1_2g"]) / 2) + m["j1_2g"]

--- a/hermes3/named_selections.py
+++ b/hermes3/named_selections.py
@@ -99,7 +99,7 @@ class CoreRing():
         # Geometry properties
         self.dr = self.a["dr"].values/2 + self.b["dr"].values/2    # Distance between cell centres of rings 
         self.R = (self.a["R"].values + self.b["R"].values)/2    # Major radius of the edge in-between rings 
-        self.A = (self.a["dl"].values + self.b["dl"].values)/2 * 2*np.pi*self.R    # Surface area of the edge in-between rings
+        self.A = (self.a["dpol"].values + self.b["dpol"].values)/2 * 2*np.pi*self.R    # Surface area of the edge in-between rings
         self.diff = self.ds.diff(dim = "x")    # Difference the entire dataset for dN/dT calculations
         
     def calculate_fluxes(self):

--- a/hermes3/plotting.py
+++ b/hermes3/plotting.py
@@ -733,7 +733,7 @@ def lineplot(
     cases,
     colors = None,
     params = ["Td+", "Te", "Td", "Ne", "Nd"],
-    regions = ["imp", "omp", "outer_lower"],
+    regions = ["imp", "omp", "outer_lower_target"],
     ylims = (None,None),
     xlims = (None,None),
     markersize = 2,
@@ -786,17 +786,17 @@ def lineplot(
                 dfs[name] = get_1d_radial_data(ds, params, "omp")
             elif region == "imp":
                 dfs[name] = get_1d_radial_data(ds, params, "imp")
-            elif region == "outer_lower":
+            elif region == "outer_lower_target":
                 dfs[name] = get_1d_radial_data(ds, params, "outer_lower_target")
             elif region == "field_line":
-                dfs[name] = get_1d_poloidal_data(ds, params, "outer_lower", sepadd = 1)
+                dfs[name] = get_1d_poloidal_data(ds, params, "outer_lower_sol", sepadd = 1)
                 # region_ds[name] = ds.hermesm.select_custom_sol_ring("outer_lower", sepadd = 0).squeeze()
 
             elif region == "1d":
                 region_ds[name] = ds.squeeze()
                 xlabel = "Distance from midplane [m]"
             else:
-                raise Exception(f"Region {region} not found")
+                raise Exception(f"Region {region} not recognised in lineplot")
             
 
         for i, param in enumerate(params):
@@ -817,7 +817,7 @@ def lineplot(
                     xlabel = "Spar [m]"
                     # m = region_ds[name].metadata
                     # xplot = region_ds[name].coords["theta"] - region_ds[name].coords["theta"][0]
-                elif region in ["omp", "imp", "outer_lower"]:  
+                elif region in ["omp", "imp", "outer_lower_target"]:  
                     xplot = dfs[name]["Srad"].values
                     data = dfs[name][param]
                     xlabel = "Dist from sep [m]"

--- a/hermes3/plotting.py
+++ b/hermes3/plotting.py
@@ -404,7 +404,7 @@ def plot_ddt(case,
              trim_timestep = 1,
              smoothing = 1, 
              dpi = 120, 
-             volume_weighted = True, 
+             volume_weighted = False, 
              normalised = True,
              ylims = (None,None), 
              xlims = (None,None)):
@@ -463,13 +463,13 @@ def plot_ddt(case,
 
 
     for param in list_params:
-        ax.plot(ds.coords["t"], res[param], label = param, lw = 1)
+        ax.plot(ds.coords["t"]*1000, res[param], label = param, lw = 1)
         
     ax.set_yscale("log")
     ax.grid(which = "major", lw = 1)
     ax.grid(which = "minor", lw = 1, alpha = 0.3)
     ax.legend(loc = "upper left", bbox_to_anchor=(1,1))
-    ax.set_xlabel("Time [s]")
+    ax.set_xlabel("Simulation time [ms]")
     ax.set_ylabel("Cell weighted residual RMS [-]")
     ax.set_title(f"Residual plot: {case.name}")
     
@@ -733,6 +733,7 @@ def lineplot(
     cases,
     colors = None,
     params = ["Td+", "Te", "Td", "Ne", "Nd"],
+    titles = None,
     regions = ["imp", "omp", "outer_lower_target"],
     ylims = (None,None),
     xlims = (None,None),
@@ -742,6 +743,7 @@ def lineplot(
     logscale = True,
     log_threshold = 10,  # Ratio of max to min required for logscale
     save_name = "",
+    combine_regions = True,
     guard_replace = False,
     auto_y_pad = 0.1,   # Padding on Y lims when automatically calculated (difference)
     auto_y_pad_log = 0.5,  # Same as above but logscale (factor)
@@ -752,6 +754,7 @@ def lineplot(
     Inputs
     --------
     cases: dict()
+    titles: optional list or dict of subplot titles. If not passed, uses params.
     """
     
     marker = "o"
@@ -765,15 +768,44 @@ def lineplot(
         if "t" in  cases[name].sizes.keys():
             cases[name] = cases[name].isel(t=-1)
 
+    mult = 0.8
+    ls = "-"
 
-    for region in regions:
-        mult = 0.8
-        fig, axes = plt.subplots(1,len(params), dpi = dpi, figsize = (4.6*len(params)*mult,5*mult), sharex = True)
-        fig.subplots_adjust(hspace = 0, wspace = 0.3, bottom = 0.25, left = 0.1, right = 0.9)
-        ls = "-"
-        
-        if type(axes) != np.ndarray:
-            axes = [axes]
+    if titles is None:
+        plot_titles = {param: param for param in params}
+    elif isinstance(titles, dict):
+        plot_titles = {param: titles.get(param, param) for param in params}
+    else:
+        if len(titles) != len(params):
+            raise ValueError("titles must have the same length as params")
+        plot_titles = dict(zip(params, titles))
+
+    if combine_regions:
+        fig, axes_grid = plt.subplots(
+            len(regions),
+            len(params),
+            dpi = dpi,
+            figsize = (4.6*len(params)*mult, 4.8*len(regions)*mult),
+            sharex = "row",
+            squeeze = False,
+        )
+        fig.subplots_adjust(hspace = 0.5, wspace = 0.3, bottom = 0.15, left = 0.1, right = 0.9, top = 0.9)
+        figure_regions = [(fig, axes_grid[row_index], region) for row_index, region in enumerate(regions)]
+    else:
+        figure_regions = []
+        for region in regions:
+            fig, axes = plt.subplots(
+                1,
+                len(params),
+                dpi = dpi,
+                figsize = (4.6*len(params)*mult,5*mult),
+                sharex = True,
+                squeeze = False,
+            )
+            fig.subplots_adjust(hspace = 0, wspace = 0.3, bottom = 0.25, left = 0.1, right = 0.9)
+            figure_regions.append((fig, axes[0], region))
+
+    for fig, axes, region in figure_regions:
             
         if region == "1d":
             print("Warning: 1D plot omitting target values")
@@ -883,8 +915,7 @@ def lineplot(
             axes[i].grid(which="both", alpha = 1)
             axes[i].grid(which="minor", visible = True)
             axes[i].set_xlabel(xlabel, fontsize=9)
-            axes[i].set_title(f"{param}", fontsize = "x-large")
-            fig.suptitle(f"{region} profiles", y=1.05)
+            axes[i].set_title(plot_titles[param], fontsize = "x-large")
             
             # print(f"{param}, datamin = {datamin:.3f}, datamax = {datamax:.3f}, datarange = {datarange:.3f}")            
             # print(f"       ymin: {ymin:.3f}, ymax: {ymax:.3f}")
@@ -893,13 +924,46 @@ def lineplot(
             #     print(f"Warning: {param} lower ylim below 0")
             axes[i].set_ylim(ymin, ymax)
 
+        if combine_regions:
+            row_left = axes[0].get_position().x0
+            row_right = axes[-1].get_position().x1
+            row_top = max(ax.get_position().y1 for ax in axes)
+            row_height = axes[0].get_position().height
+
+            fig.text(
+                (row_left + row_right) / 2,
+                row_top + 0.2 * row_height,
+                f"--- {region} ---",
+                transform = fig.transFigure,
+                ha = "center",
+                va = "bottom",
+                fontsize = "xx-large",
+                color = "black",
+                # fontweight = "bold"
+            )
+        else:
+            fig.suptitle(
+                f"--- {region}--- ",
+                x = 0.5,
+                y = 1.05,
+                ha = "center",
+                color = "black",
+                fontweight = "bold"
+            )
+
         legend_items = []
         for j, name in enumerate(cases.keys()):
             legend_items.append(mpl.lines.Line2D([0], [0], color=colors[j], lw=2, ls = ls))
-            
-        fig.legend(legend_items, cases.keys(), ncol = len(cases), loc = "upper center", bbox_to_anchor=(0.5,0.15))
+
+        if not combine_regions:
+            fig.legend(legend_items, cases.keys(), ncol = len(cases), loc = "upper center", bbox_to_anchor=(0.5,0.15))
+            if save_name != "":
+                fig.savefig(f"{save_name}_{region}.png", bbox_inches="tight", pad_inches=0.2)
+
+    if combine_regions:
+        fig.legend(legend_items, cases.keys(), ncol = len(cases), loc = "upper center", bbox_to_anchor=(0.5,0.08))
         if save_name != "":
-            fig.savefig(f"{save_name}_{region}.png", bbox_inches="tight", pad_inches=0.2)
+            fig.savefig(f"{save_name}.png", bbox_inches="tight", pad_inches=0.2)
         # fig.tight_layout()
         
 def create_norm(logscale, norm, vmin, vmax):
@@ -1274,7 +1338,7 @@ def plot_2d_timeslices(ds, param, tinds,
 
 def plot2d(
     toplot,
-    clean_guards=True,
+    clear_guards=True,
     ylim=(None, None),
     xlim=(None, None),
     title="",
@@ -1294,12 +1358,26 @@ def plot2d(
 ):
 
     """
-    User friendly plot of a number of dataarrays in a row.
+    Plot a row of 2D Hermes/BOUT data arrays.
 
-    subplot_size : width of each subplot in inches. Height is derived from the
-        R/Z aspect ratio of the data (or ylim/xlim if provided). Width is always
-        the same, so fonts/ticks/lines are always the same physical size regardless
-        of shape. Override with subplot_width or subplot_height (inches).
+    Parameters
+    ----------
+    toplot : list of dict
+        One entry per subplot. Each dict must contain:
+        - ``data``: the DataArray to plot.
+
+        Optional per-subplot keys include:
+        - ``title``: subplot title. Falls back to the data name when omitted.
+        - ``vmin``, ``vmax``, ``logscale``: forwarded to the polygon plotter.
+        - any other keyword accepted by ``data.bout.polygon()``.
+
+        Example:
+        ``[{"title": "Te", "data": ds["Te"], "vmin": 1, "vmax": 100}]``
+
+    subplot_size : float
+        Width of each subplot in inches. Height is derived from the R/Z aspect
+        ratio of the data, or from ``xlim``/``ylim`` if those are supplied.
+        Override directly with ``subplot_width`` or ``subplot_height``.
     """
 
     numplots = len(toplot)
@@ -1361,7 +1439,7 @@ def plot2d(
             figtitle = ""
             print("WARNING: Passed dataarray with no name or title")
         settings = {**defaults, **inputs, **kwargs}    
-        if clean_guards == True: data = data.hermesm.clean_guards() 
+        if clear_guards == True: data = data.hermes.clear_guards() 
 
         data.bout.polygon(ax = axes[i], **settings)
         axes[i].set_title(figtitle)
@@ -1504,7 +1582,7 @@ def plot_cvode_performance_single(ds):
 
     fig.tight_layout()
     
-def plot_fluctuations(ds, params, mode = "variable_max", ylims = (None,None), xlims = (None,None)):
+def plot_fluctuations(ds, params, mode = "variable_max", ylims = (None,None), xlims = (None,None), vmin = None, vmax = None):
     """
     Plot variable fluctuations over domain (defined in params as list).
     Mode:
@@ -1550,23 +1628,24 @@ def plot_fluctuations(ds, params, mode = "variable_max", ylims = (None,None), xl
         elif mode == "rel_ddt_rms":
             ddt_param = ds[f"ddt({param})"]
             rel_ddt_param = ddt_param / da_param
-            data = np.sqrt((rel_ddt_param)**2).mean(dim="t")
-            suptitle = "RMS relative ddt"
+            data = np.sqrt((rel_ddt_param**2).mean(dim="t"))
+            suptitle = r"$\sqrt{\left\langle \left(\frac{1}{x}\frac{dx}{dt}\right)^2 \right\rangle_t}$"
         elif mode == "ddt":
             ddt_param = ds[f"ddt({param})"]
             data = ddt_param
             suptitle = "ddt"
         else:
-            raise ValueError(f"Mode {mode} not recognised. Has to be variable_max, variable_rms, ddt_max or ddt_rms")
+            raise ValueError(f"Mode {mode} not recognised")
                 
         ax = axes[i]
-        data.hermesm.clean_guards().bout.polygon(ax = ax, cmap = "Spectral_r", targets = False, 
+        data.hermes.clear_guards().bout.polygon(ax = ax, cmap = "Spectral_r", targets = False, 
                                                                 separatrix_kwargs = dict(color="white", linestyle = "-", linewidth = 0),
-                                                                antialias = False,
+                                                                antialias = True,
                                                                 logscale = False,
+                                                                vmin = vmin, vmax = vmax
                                                                 # vmin = np.nanmin(data.values), vmax = np.nanmax(data.values),
                                                                 )
-        fig.suptitle(suptitle, y = 0.85)
+        fig.suptitle(suptitle)
     
         ax.set_title(param)
         ax.set_xlabel("")

--- a/hermes3/plotting.py
+++ b/hermes3/plotting.py
@@ -385,7 +385,7 @@ class Monitor2D():
             
         elif self.mode == "field_line_history":
             norm = create_norm(logscale = settings["log"], norm = None, vmin = settings["vmin"], vmax = settings["vmax"])
-            self.case.select_custom_sol_ring(1, "outer_lower")[name].plot(x = "t", ax = ax, cmap = "Spectral_r", norm = norm, cbar_kwargs={"label":""})
+            self.case.select_custom_sol_ring("outer_lower", sepadd = 1)[name].plot(x = "t", ax = ax, cmap = "Spectral_r", norm = norm, cbar_kwargs={"label":""})
             ax.set_title(f"1st SOL ring {name}")
             
         else:

--- a/hermes3/selectors.py
+++ b/hermes3/selectors.py
@@ -3,6 +3,7 @@ from xbout import BoutDatasetAccessor, BoutDataArrayAccessor
 from hermes3.plotting import *
 from hermes3.front_tracking import *
 import xhermes
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import scipy
@@ -61,7 +62,8 @@ def get_1d_radial_data(ds,
                        poloidal_index = None, 
                        guards = False,
                        sol = True,
-                       core = True
+                       core = True,
+                       debug = False
                        ):
     """
     Return a Pandas Dataframe with a radial slice of data in the given region
@@ -70,6 +72,9 @@ def get_1d_radial_data(ds,
     Regions = omp, imp, inner_lower, inner_upper, outer_lower, outer_upper.
     alternatively, you can specify a poloidal index to get data at that index.
     """
+
+    if debug:
+        print(f"Region: {region}")
 
     # ---- helpers ----
     def _quad_at_zero(Z1d, V1d):
@@ -509,24 +514,33 @@ def get_1d_poloidal_data(
     target_first : bool, if True, reverse the dataframe so that 0 distance is at the target
 
     """
-    if region == "all":
-        region = "sol"
-    elif region in ["inner", "outer", "inner_lower", "inner_upper", "outer_lower", "outer_upper"]:
-        region = f"{region}_sol"
+
 
     m = ds.metadata
 
     if "t" in ds.sizes:
         raise Exception("get_1d_poloidal_data doesn't support multiple time slices")
     
+    if "guards" in region or "extra" in region:
+        raise ValueError("Region should not include 'guards' or 'extra', these are added automatically based on the region and flags")
+    
     if "core" in region and any([target_first, interpolate_midplane]):
         raise Exception("target_first and interpolate_midplane are incompatible with region=core")
-    
-    if "divertor" in region and interpolate_midplane:
-        raise ValueError("Interpolate midplane should not be used for divertor regions!")
 
     if any([x in region for x in ["pfr", "core"]]) and interpolate_midplane:
-        raise ValueError("Interpolate midplane should not be used for PFR or core regions!")
+        raise ValueError("interpolate_midplane is incompatible with PFR/core as they don't include the midplane!")
+    
+    selector_region = region
+    
+    # Include guards if requested and if the region has guards
+    if any([name in region for name in ["sol", "divertor", "pfr"]]):
+        if guards:
+            selector_region = f"{region}_guards"
+    
+    # Include cell beyond the midplane if interpolating to midplane
+    if any([name in region for name in ["sol", "upstream"]]):
+        if interpolate_midplane:
+            selector_region = f"{region}_extra"
     
 
     ## Select SOL region
@@ -540,7 +554,7 @@ def get_1d_poloidal_data(
         df = _interpolate_exact_poloidal_ring(
             ds, 
             params, 
-            region, 
+            selector_region, 
             sepdist = sepdist, 
             radial_start_region = radial_start_region,
             debug = False
@@ -548,7 +562,7 @@ def get_1d_poloidal_data(
     
     # 2. Or get it at a specific SOL ring index, or the closest SOL ring to a given sepdist
     else:
-        reg = ds.hermesm.select_custom_sol_ring(region, sepadd = sepadd, sepdist = sepdist).squeeze()
+        reg = ds.hermesm.select_custom_sol_ring(selector_region, sepadd = sepadd, sepdist = sepdist).squeeze()
 
         df = pd.DataFrame()
         df["R"] = reg["R"].values
@@ -575,8 +589,8 @@ def get_1d_poloidal_data(
         df_interp = pd.DataFrame()
         Z = df["Z"].values
         R = df["R"].values
-        ds = np.sqrt(np.diff(R)**2 + np.diff(Z)**2)
-        s = np.concatenate(([0], np.cumsum(ds)))  # shape (N,)
+        ds_pol = np.sqrt(np.diff(R)**2 + np.diff(Z)**2)
+        s = np.concatenate(([0], np.cumsum(ds_pol)))  # shape (N,)
         
         # R_spline = scipy.interpolate.UnivariateSpline(s, R, s=0)
         # Z_spline = scipy.interpolate.UnivariateSpline(s, Z, s=0)
@@ -634,7 +648,7 @@ def get_1d_poloidal_data(
 
 
     if "sol" in region:
-        xpoint_index_name = f"{region.replace("_sol", "")}_xpoint"
+        xpoint_index_name = f"{region.replace("_sol","")}_xpoint"
         global_xpoint_index = xhermes.selector_poloidal(ds, xpoint_index_name)
 
         Xpoint_index = df[df["theta_idx"] == global_xpoint_index].index[0]
@@ -656,13 +670,30 @@ def get_1d_poloidal_data(
         raise ValueError(f"Unknown region {region} for region labeling")
     
     # Take out guard cell if needed
-    if not guards and any([x in region for x in ["sol", "divertor", "pfr"]]):
-        df = df.iloc[:-1]
+    # NOTE: Shouldn't be necessary as now guard selection is at the selector level
+    # if not guards and "guards" in region:
+    #     df = df.iloc[:-2]
             
     # Flip data so target is first if needed
     if target_first:
         df["Spol"] = df["Spol"].iloc[-1] - df["Spol"]
         df["Spar"] = df["Spar"].iloc[-1] - df["Spar"]
         df = df.iloc[::-1]
+
+    if debug:
+        fig, ax = plt.subplots(dpi = 150)
+        ds["Td"].bout.polygon(
+            ax = ax,
+            grid_only = True,
+            linecolor = "k",
+            linewidth = 0.1,
+            antialias = True,
+            separatrix = False,
+            add_colorbar = False,
+        )
+        ax.plot(df["R"], df["Z"], "-", c = "deeppink", markersize = 3)
+        ax.plot(df.iloc[0]["R"], df.iloc[0]["Z"], "o", markersize = 5, c = "green")
+        ax.plot(df.iloc[-1]["R"], df.iloc[-1]["Z"], "o", markersize = 5, c = "red")
+        ax.set_title("")
         
     return df

--- a/hermes3/selectors.py
+++ b/hermes3/selectors.py
@@ -189,6 +189,7 @@ def get_1d_radial_data(ds,
             else:
                 print(f"Parameter {param} not found")
     
+
     # Calculate radial distance from separatrix (vectorized)
     dr = df["dr"].to_numpy()
     df["Srad"] = np.cumsum(dr) - 0.5 * dr
@@ -206,6 +207,8 @@ def get_1d_radial_data(ds,
     df["region"] = ""
     df.loc[df["Srad"] > 0, "region"] = "sol"
     df.loc[df["Srad"] < 0, "region"] = "core"
+
+    df["radial_index"] = df.index.values
 
     # Remove guards if necessary
     # NOTE: you must preserve the original index here!

--- a/hermes3/selectors.py
+++ b/hermes3/selectors.py
@@ -341,18 +341,23 @@ def _interpolate_exact_sol_ring(
     params,
     region,
     sepdist,
+    radial_start_region=None,
     debug = False,
     ):
     """
     This returns poloidal data radially interpolated to the same psi value as a desired
     separatrix distance at the midplane. This means the data is not affected by radial resolution.
     Good for code comparisons.
+
+    NOTE: Only poloidally contiguous regions are supported, i.e. those that you can get with
+    _get_poloidal_range.
     
     Parameters
     ----------
     ds : Dataset to use (must be loaded with guards)
     params : list of parameters to extract
     region : string, region to extract data from (inner_lower, inner_upper, outer_lower, outer_upper)
+    radial_start_region : string, region to use for the radial slice on which separatrix distance is defined
     sepdist : float, distance from separatrix to extract data from
     
     Returns
@@ -360,42 +365,59 @@ def _interpolate_exact_sol_ring(
     df : DataFrame with data along the field line to be used by get_1d_poloidal_data
     """
 
+    if "sol" in region:
+        if sepdist < 0:
+            raise ValueError("sepdist must be positive for SOL regions")
+    else:
+        if sepdist > 0:
+            raise ValueError("sepdist must be negative for core or PFR regions")
+
     
     m = ds.metadata
     extra_params = ["R", "Z", "psi_poloidal", "dpol", "Bxy", "Bpxy"]  # Needed in get_1d_poloidal_data
     all_params = extra_params + params
 
     ## This comes from _select_custom_sol_ring
-    start, end = _get_poloidal_range(ds, region)   
+    # start, end = _get_poloidal_range(ds, region)   
+    poloidal_selection = m["poloidal_slices"][region]
+    poloidal_indices = ds["theta_idx"].values[poloidal_selection]
 
-    ## Need to choose the psi we want based on an accurate midplane slice
-    if "outer" in region:
-        start_region = "omp"
-    elif "inner" in region:
-        start_region = "imp"
-    else:
-        raise Exception("Region not recognised, needs to mention inner or outer")
+    ## Get radial slice to figure out field line starting point based on sepdist
+    if radial_start_region is None:
+        if "outer" in region:
+            radial_start_region = "omp"
+        elif "inner" in region:
+            radial_start_region = "imp"
+        else:
+            raise Exception(f"Radial start region must be provided for region {region}")
 
-    midplane = get_1d_radial_data(ds, params = all_params, region = start_region, core = False)
+    radial_slice = get_1d_radial_data(ds, params = all_params, region = radial_start_region, core = True)
 
     # Find exact psi at chosen separatrix distance
-    psi = scipy.interpolate.interp1d(midplane["Srad"], midplane["psi_poloidal"])(sepdist)
+    psi = scipy.interpolate.interp1d(radial_slice["Srad"], radial_slice["psi_poloidal"])(sepdist)
 
     ## Interpolate data on the same psi and return
     df = pd.DataFrame()
     if debug:
-        fig, ax = plt.subplots()
-    for i in range(start,end):
-        radial = get_1d_radial_data(ds, params = all_params, poloidal_index = i, core = False)
+        fig, ax = plt.subplots(dpi = 150)
+        ds["Td"].bout.polygon(ax = ax, grid_only = True, linecolor = "k", linewidth = 0.1, antialias = True, separatrix = False, add_colorbar = False)
+
+    # For every poloidal index, get the radial data, interpolate to the correct sepdist and append to dataframe
+    for i in poloidal_indices:
+        radial = get_1d_radial_data(ds, params = all_params, poloidal_index = i, core = True)
         
         if debug:
-            ds["Td"].bout.polygon(ax = ax, grid_only = True, linecolor = "k", linewidth = 0.1, antialias = True, separatrix = False, add_colorbar = False)
             ax.plot(radial["R"], radial["Z"], "o", markersize = 3, alpha = 0.5)
         
         for param in all_params:
             df.loc[i, param] = scipy.interpolate.interp1d(radial["psi_poloidal"], radial[param])(psi)
             
     df = df.reset_index(drop=True)
+
+    if debug:
+        ax.plot(df["R"], df["Z"], c = "deeppink")
+        ax.set_title("")
+        
     
     return df
 
@@ -434,6 +456,7 @@ def get_1d_poloidal_data(
     target_first = False,
     interpolate_midplane = True,
     interpolate_radial = False,
+    radial_start_region = None,
     interpolate_poloidal = False,
     interpolate_poloidal_resolution = 100):
     """
@@ -453,10 +476,15 @@ def get_1d_poloidal_data(
     target_first : bool, if True, reverse the dataframe so that 0 distance is at the target
 
     """
+    m = ds.metadata
+
     if "t" in ds.sizes:
         raise Exception("get_1d_poloidal_data doesn't support multiple time slices")
     
+    if "core" in region and any([target_first, interpolate_midplane]):
+        raise Exception("target_first and interpolate_midplane are incompatible with region=core")
     
+
     ## Select SOL region
     # This is always in index ascending order, and goes one point past the midplane
     
@@ -470,6 +498,7 @@ def get_1d_poloidal_data(
             params, 
             region, 
             sepdist = sepdist, 
+            radial_start_region = radial_start_region,
             debug = False
         )
     
@@ -532,14 +561,15 @@ def get_1d_poloidal_data(
         df = df.iloc[::-1].reset_index(drop = True)
         
     # Check and delete any extraneous points upstream of the midplane
-    signs = np.sign(df["Z"])
-    sign_changes = signs != signs.shift()
-    change_indices = df.index[sign_changes][1:]
-    if len(change_indices) > 1:
-        raise Exception("Multiple sign changes in Z. Haven't considered this yet")
+    if interpolate_midplane:
+        signs = np.sign(df["Z"])
+        sign_changes = signs != signs.shift()
+        change_indices = df.index[sign_changes][1:]
+        if len(change_indices) > 1:
+            raise Exception("Multiple sign changes in Z. Haven't considered this yet")
 
-    idx_before_mp = change_indices[0]-1
-    df = df.iloc[idx_before_mp:].reset_index(drop = True)
+        idx_before_mp = change_indices[0]-1
+        df = df.iloc[idx_before_mp:].reset_index(drop = True)
 
     # Interpolate start of field line onto Z = 0  (between midplane_a and midplane_b)
     # Assumes only one point upstream of midplane

--- a/hermes3/selectors.py
+++ b/hermes3/selectors.py
@@ -18,24 +18,30 @@ def _get_poloidal_range(ds, region):
     if m["topology"] == "connected-double-null":
 
         ## This comes from _select_custom_sol_ring
-        if region == "inner_lower":
+        if region == "inner_lower_sol":
             start = m["MYG"]
             end = m["imp_a"] + 1
-        elif region == "inner_upper":
+        elif region == "inner_upper_sol":
             start = m["imp_b"]
             end = m["ny_inner"] + m["MYG"]
-        elif region == "outer_lower":
+        elif region == "outer_lower_sol":
             start = m["omp_a"]
             end = m["nyg"] - m["MYG"]
-        elif region == "outer_upper":
+        elif region == "outer_upper_sol":
             start = m["ny_inner"] + m["MYG"]*3
             end = m["omp_b"]+1
-        elif region == "inner":
+        elif region == "inner_sol":
             start = m["MYG"]
             end = m["ny_inner"] + m["MYG"]
-        elif region == "outer":
+        elif region == "outer_sol":
             start = m["ny_inner"] + m["MYG"] * 3
             end = m["nyg"] - m["MYG"]
+        elif region == "inner_core":
+            start = m["j1_1g"]+1
+            end = m["j2_1g"]+1
+        elif region == "outer_core":
+            start = m["j1_2g"]+1
+            end = m["j2_2g"]+1
 
         else:
             raise ValueError(f"Unknown region {region} for poloidal range")

--- a/hermes3/selectors.py
+++ b/hermes3/selectors.py
@@ -540,15 +540,19 @@ def get_1d_poloidal_data(
         df["Spar"] -= df["Spar"].iloc[0]  # Now 0 is at Z = 0
 
 
-    global_xpoint_index = xhermes.slice_poloidal(ds, f"{region}_xpoint")
+    if "sol" in region:
+        xpoint_index_name = f"{region.replace("_sol", "")}_xpoint"
+        global_xpoint_index = xhermes.slice_poloidal(ds, xpoint_index_name)
 
-    Xpoint_index = df[df["theta_idx"] == global_xpoint_index].index[0]
+        Xpoint_index = df[df["theta_idx"] == global_xpoint_index].index[0]
 
-    # df["Xpoint"] = 0
-    # df.loc[Xpoint_index, "Xpoint"] = 1
+        # df["Xpoint"] = 0
+        # df.loc[Xpoint_index, "Xpoint"] = 1
 
-    df.loc[:Xpoint_index, "region"] = "upstream"
-    df.loc[Xpoint_index:, "region"] = "divertor"
+        df.loc[:Xpoint_index, "region"] = "upstream"
+        df.loc[Xpoint_index:, "region"] = "divertor"
+    else:
+        df["region"] = "core"
             
     # Flip data so target is first if needed
     if target_first:

--- a/hermes3/selectors.py
+++ b/hermes3/selectors.py
@@ -367,12 +367,16 @@ def _interpolate_exact_poloidal_ring(
     df : DataFrame with data along the field line to be used by get_1d_poloidal_data
     """
 
-    if "sol" in region:
-        if sepdist < 0 or sepadd < 0:
+    if any([name in region for name in ["sol", "upstream", "divertor"]]):
+        if sepdist is not None and sepdist < 0:
             raise ValueError("sepdist must be positive for SOL regions")
+        if sepadd is not None and sepadd < 0:
+            raise ValueError("sepadd must be positive for SOL regions")
     else:
-        if sepdist > 0 or sepadd > 0:
+        if sepdist is not None and sepdist > 0:
             raise ValueError("sepdist must be negative for core or PFR regions")
+        if sepadd is not None and sepadd > 0:
+            raise ValueError("sepadd must be negative for core or PFR regions")
 
     
     m = ds.metadata
@@ -386,12 +390,22 @@ def _interpolate_exact_poloidal_ring(
 
     ## Get radial slice to figure out field line starting point based on sepdist
     if radial_start_region == "auto":
-        if "outer" in region:
+        if region == "outer_lower_pfr":
+            radial_start_region = "outer_lower_target"
+        elif region == "outer_upper_pfr":
+            radial_start_region = "outer_upper_target"
+        elif region == "inner_lower_pfr":
+            radial_start_region = "inner_lower_target"
+        elif region == "inner_upper_pfr":
+            radial_start_region = "inner_upper_target"
+        elif "outer" in region:
             radial_start_region = "omp"
         elif "inner" in region:
             radial_start_region = "imp"
-        else:
-            raise Exception(f"Radial start region must be provided for region {region}")
+        elif region == "lower_pfr":
+            radial_start_region = "outer_lower_target"
+        elif region == "upper_pfr":
+            radial_start_region = "outer_upper_target"
 
     radial_slice = get_1d_radial_data(ds, params = all_params, region = radial_start_region, core = True)
 
@@ -460,12 +474,14 @@ def get_1d_poloidal_data(
     region, 
     sepdist = None, 
     sepadd = None,
+    guards = False, 
     target_first = False,
     interpolate_midplane = True,
     interpolate_radial = False,
     radial_start_region = None,
     interpolate_poloidal = False,
-    interpolate_poloidal_resolution = 100):
+    interpolate_poloidal_resolution = 100,
+    debug = False):
     """
     Return a dataframe with data along a field line as well as poloidal and parallel connection lengths.
     Refer to get_custom_sol_ring for the indexing routine. 
@@ -491,7 +507,10 @@ def get_1d_poloidal_data(
     if "core" in region and any([target_first, interpolate_midplane]):
         raise Exception("target_first and interpolate_midplane are incompatible with region=core")
     
-    if region in ["pfr", "core"] and interpolate_midplane:
+    if "divertor" in region and interpolate_midplane:
+        raise ValueError("Interpolate midplane should not be used for divertor regions!")
+
+    if any([x in region for x in ["pfr", "core"]]) and interpolate_midplane:
         raise ValueError("Interpolate midplane should not be used for PFR or core regions!")
     
 
@@ -564,8 +583,14 @@ def get_1d_poloidal_data(
         df = df_interp
         
         
-    # Flip outer upper and inner lower so that they start at midplane
-    if any([x in region for x in ["outer_upper", "inner_lower"]]):
+    # Flip outer upper and inner lower so that the regions have a
+    # consistent orientation across all legs.
+    if any([name in region for name in [
+        "outer_upper_sol", "inner_lower_sol",
+        "outer_upper_upstream", "inner_lower_upstream",
+        "outer_upper_divertor", "inner_lower_divertor",
+        "outer_upper_pfr", "inner_lower_pfr"
+        ]]):
         df["Spol"] = df["Spol"].iloc[-1] - df["Spol"]
         df["Spar"] = df["Spar"].iloc[-1] - df["Spar"]
         df = df.iloc[::-1].reset_index(drop = True)
@@ -604,8 +629,20 @@ def get_1d_poloidal_data(
 
         df.loc[:Xpoint_index, "region"] = "upstream"
         df.loc[Xpoint_index:, "region"] = "divertor"
-    else:
+    elif "upstream" in region:
+        df["region"] = "upstream"
+    elif "divertor" in region:
+        df["region"] = "divertor"
+    elif "pfr" in region:
+        df["region"] = "pfr"
+    elif "core" in region:
         df["region"] = "core"
+    else:
+        raise ValueError(f"Unknown region {region} for region labeling")
+    
+    # Take out guard cell if needed
+    if not guards and any([x in region for x in ["sol", "divertor", "pfr"]]):
+        df = df.iloc[:-1]
             
     # Flip data so target is first if needed
     if target_first:

--- a/hermes3/selectors.py
+++ b/hermes3/selectors.py
@@ -6,50 +6,52 @@ import xhermes
 import numpy as np
 import scipy
 
-def _get_poloidal_range(ds, region):
-    """
-    Returns poloidal region start and end indices in a tuple.
-    Each region is a quarter of a CDN topology corresponding to a 
-    divertor. The regions are all in a positive index order.
-    The regions extend past the midplane by one point.
-    """
-    m = ds.metadata
+## Deprecated by xhermes
+# poloidal slices now found in ds.metadata["poloidal_slices"]
+# def _get_poloidal_range(ds, region):
+#     """
+#     Returns poloidal region start and end indices in a tuple.
+#     Each region is a quarter of a CDN topology corresponding to a 
+#     divertor. The regions are all in a positive index order.
+#     The regions extend past the midplane by one point.
+#     """
+#     m = ds.metadata
     
-    if m["topology"] == "connected-double-null":
+#     if m["topology"] == "connected-double-null":
 
-        ## This comes from _select_custom_sol_ring
-        if region == "inner_lower_sol":
-            start = m["MYG"]
-            end = m["imp_a"] + 1
-        elif region == "inner_upper_sol":
-            start = m["imp_b"]
-            end = m["ny_inner"] + m["MYG"]
-        elif region == "outer_lower_sol":
-            start = m["omp_a"]
-            end = m["nyg"] - m["MYG"]
-        elif region == "outer_upper_sol":
-            start = m["ny_inner"] + m["MYG"]*3
-            end = m["omp_b"]+1
-        elif region == "inner_sol":
-            start = m["MYG"]
-            end = m["ny_inner"] + m["MYG"]
-        elif region == "outer_sol":
-            start = m["ny_inner"] + m["MYG"] * 3
-            end = m["nyg"] - m["MYG"]
-        elif region == "inner_core":
-            start = m["j1_1g"]+1
-            end = m["j2_1g"]+1
-        elif region == "outer_core":
-            start = m["j1_2g"]+1
-            end = m["j2_2g"]+1
+#         ## This comes from _select_custom_sol_ring
+#         if region == "inner_lower_sol":
+#             start = m["MYG"]
+#             end = m["imp_a"] + 1
+#         elif region == "inner_upper_sol":
+#             start = m["imp_b"]
+#             end = m["ny_inner"] + m["MYG"]
+#         elif region == "outer_lower_sol":
+#             start = m["omp_a"]
+#             end = m["nyg"] - m["MYG"]
+#         elif region == "outer_upper_sol":
+#             start = m["ny_inner"] + m["MYG"]*3
+#             end = m["omp_b"]+1
+#         elif region == "inner_sol":
+#             start = m["MYG"]
+#             end = m["ny_inner"] + m["MYG"]
+#         elif region == "outer_sol":
+#             start = m["ny_inner"] + m["MYG"] * 3
+#             end = m["nyg"] - m["MYG"]
+#         elif region == "inner_core":
+#             start = m["j1_1g"]+1
+#             end = m["j2_1g"]+1
+#         elif region == "outer_core":
+#             start = m["j1_2g"]+1
+#             end = m["j2_2g"]+1
 
-        else:
-            raise ValueError(f"Unknown region {region} for poloidal range")
+#         else:
+#             raise ValueError(f"Unknown region {region} for poloidal range")
         
-    else:
-        raise ValueError(f"Topology {m['topology']} not yet supported")
+#     else:
+#         raise ValueError(f"Topology {m['topology']} not yet supported")
     
-    return (start,end)
+#     return (start,end)
 
 def get_1d_radial_data(ds, 
                        params, 
@@ -116,11 +118,17 @@ def get_1d_radial_data(ds,
     
     # Interpolate to Z = 0 for IMP or OMP
     if region == "omp" or region == "imp":
+
+        omp_a = m["poloidal_slices"]["outer_upper_midplane"]
+        omp_b = m["poloidal_slices"]["outer_lower_midplane"]
+        imp_a = m["poloidal_slices"]["inner_upper_midplane"]
+        imp_b = m["poloidal_slices"]["inner_lower_midplane"]
+        
         # slice a narrow band around the midplane
         if region == "omp":
-            reg = ds.isel(x=xslice, theta=slice(m["omp_a"] - 2, m["omp_b"] + 2))
+            reg = ds.isel(x=xslice, theta=slice(omp_a - 2, omp_b + 2))
         else:
-            reg = ds.isel(x=xslice, theta=slice(m["imp_a"] - 2, m["imp_b"] + 2))
+            reg = ds.isel(x=xslice, theta=slice(imp_a - 2, imp_b + 2))
 
         # Ensure a single chunk along the core dim for gufunc
         # (cheap here since theta band is small)
@@ -158,15 +166,20 @@ def get_1d_radial_data(ds,
         df = df.drop(columns=["t"], errors="ignore")
 
     else:
-        # Take region directly from named selection
-        if region in ["inner_lower_target", "inner_upper_target", "outer_lower_target", "outer_upper_target"]:
-            reg = ds.hermesm.select_region(region).squeeze()
-        
-        # Get data by poloidal index
-        elif poloidal_index is None:
-            raise Exception("If not requesting midplane, please pass poloidal_index")
-        else:
+
+        if poloidal_index is not None and region is not None:
+            raise Exception("Please specify only one of region or poloidal_index, not both")
+
+        if poloidal_index is not None:
             reg = ds.isel(x=xslice, theta=poloidal_index).squeeze()
+
+        # Take region directly from named selection
+        if region is not None:
+            if region in m["poloidal_slices"]:
+                reg = ds.hermes.select_region(region).squeeze()
+            else:
+                raise ValueError(f"Unknown region {region}.")
+            
     
         df["dr"] = reg["dr"].values
 
@@ -542,7 +555,7 @@ def get_1d_poloidal_data(
 
     if "sol" in region:
         xpoint_index_name = f"{region.replace("_sol", "")}_xpoint"
-        global_xpoint_index = xhermes.slice_poloidal(ds, xpoint_index_name)
+        global_xpoint_index = m["poloidal_slices"][xpoint_index_name]
 
         Xpoint_index = df[df["theta_idx"] == global_xpoint_index].index[0]
 

--- a/hermes3/selectors.py
+++ b/hermes3/selectors.py
@@ -336,12 +336,13 @@ def get_1d_radial_data_old(ds,
         
     return df
 
-def _interpolate_exact_sol_ring(
+def _interpolate_exact_poloidal_ring(
     ds,
     params,
     region,
-    sepdist,
-    radial_start_region=None,
+    sepadd = None,
+    sepdist = None,
+    radial_start_region="auto",
     debug = False,
     ):
     """
@@ -358,7 +359,8 @@ def _interpolate_exact_sol_ring(
     params : list of parameters to extract
     region : string, region to extract data from (inner_lower, inner_upper, outer_lower, outer_upper)
     radial_start_region : string, region to use for the radial slice on which separatrix distance is defined
-    sepdist : float, distance from separatrix to extract data from
+    sepdist : float, distance from separatrix to extract data from (use either this or sepadd, not both)
+    sepadd : int, SOL ring index to extract data from (starting from one after separatrix)
     
     Returns
     -------
@@ -366,10 +368,10 @@ def _interpolate_exact_sol_ring(
     """
 
     if "sol" in region:
-        if sepdist < 0:
+        if sepdist < 0 or sepadd < 0:
             raise ValueError("sepdist must be positive for SOL regions")
     else:
-        if sepdist > 0:
+        if sepdist > 0 or sepadd > 0:
             raise ValueError("sepdist must be negative for core or PFR regions")
 
     
@@ -383,7 +385,7 @@ def _interpolate_exact_sol_ring(
     poloidal_indices = ds["theta_idx"].values[poloidal_selection]
 
     ## Get radial slice to figure out field line starting point based on sepdist
-    if radial_start_region is None:
+    if radial_start_region == "auto":
         if "outer" in region:
             radial_start_region = "omp"
         elif "inner" in region:
@@ -394,7 +396,12 @@ def _interpolate_exact_sol_ring(
     radial_slice = get_1d_radial_data(ds, params = all_params, region = radial_start_region, core = True)
 
     # Find exact psi at chosen separatrix distance
-    psi = scipy.interpolate.interp1d(radial_slice["Srad"], radial_slice["psi_poloidal"])(sepdist)
+    if sepdist is not None:
+        psi = scipy.interpolate.interp1d(radial_slice["Srad"], radial_slice["psi_poloidal"])(sepdist)
+    elif sepadd is not None:
+        psi = radial_slice.loc[radial_slice.index[sepadd], "psi_poloidal"]
+    else:
+        raise ValueError("Either sepdist or sepadd must be provided")
 
     ## Interpolate data on the same psi and return
     df = pd.DataFrame()
@@ -484,6 +491,9 @@ def get_1d_poloidal_data(
     if "core" in region and any([target_first, interpolate_midplane]):
         raise Exception("target_first and interpolate_midplane are incompatible with region=core")
     
+    if region in ["pfr", "core"] and interpolate_midplane:
+        raise ValueError("Interpolate midplane should not be used for PFR or core regions!")
+    
 
     ## Select SOL region
     # This is always in index ascending order, and goes one point past the midplane
@@ -493,7 +503,7 @@ def get_1d_poloidal_data(
         if sepdist is None:
             raise Exception("sepdist must be specified if interpolate_radial is True")
         
-        df = _interpolate_exact_sol_ring(
+        df = _interpolate_exact_poloidal_ring(
             ds, 
             params, 
             region, 

--- a/hermes3/selectors.py
+++ b/hermes3/selectors.py
@@ -176,7 +176,7 @@ def get_1d_radial_data(ds,
         # Take region directly from named selection
         if region is not None:
             if region in m["poloidal_slices"]:
-                reg = ds.hermes.select_region(region).squeeze()
+                reg = ds.hermes.select_region(region, guards = True).squeeze()
             else:
                 raise ValueError(f"Unknown region {region}.")
             

--- a/hermes3/selectors.py
+++ b/hermes3/selectors.py
@@ -4,7 +4,9 @@ from hermes3.plotting import *
 from hermes3.front_tracking import *
 import xhermes
 import numpy as np
+import pandas as pd
 import scipy
+import xarray as xr
 
 ## Deprecated by xhermes
 # poloidal slices now found in ds.metadata["poloidal_slices"]
@@ -119,10 +121,10 @@ def get_1d_radial_data(ds,
     # Interpolate to Z = 0 for IMP or OMP
     if region == "omp" or region == "imp":
 
-        omp_a = m["poloidal_slices"]["outer_upper_midplane"]
-        omp_b = m["poloidal_slices"]["outer_lower_midplane"]
-        imp_a = m["poloidal_slices"]["inner_upper_midplane"]
-        imp_b = m["poloidal_slices"]["inner_lower_midplane"]
+        omp_a = xhermes.selector_poloidal(ds, "outer_upper_midplane")
+        omp_b = xhermes.selector_poloidal(ds, "outer_lower_midplane")
+        imp_a = xhermes.selector_poloidal(ds, "inner_upper_midplane")
+        imp_b = xhermes.selector_poloidal(ds, "inner_lower_midplane")
         
         # slice a narrow band around the midplane
         if region == "omp":
@@ -175,8 +177,8 @@ def get_1d_radial_data(ds,
 
         # Take region directly from named selection
         if region is not None:
-            if region in m["poloidal_slices"]:
-                reg = ds.hermes.select_region(region, guards = True).squeeze()
+            if region in xhermes.selector_poloidal(ds, return_available = True):
+                reg = ds.hermes.select_region(radial_region = "domain_guards", poloidal_region = region).squeeze()
             else:
                 raise ValueError(f"Unknown region {region}.")
             
@@ -370,6 +372,11 @@ def _interpolate_exact_poloidal_ring(
     df : DataFrame with data along the field line to be used by get_1d_poloidal_data
     """
 
+    if region == "all":
+        region = "sol"
+    elif region in ["inner", "outer", "inner_lower", "inner_upper", "outer_lower", "outer_upper"]:
+        region = f"{region}_sol"
+
     if any([name in region for name in ["sol", "upstream", "divertor"]]):
         if sepdist is not None and sepdist < 0:
             raise ValueError("sepdist must be positive for SOL regions")
@@ -388,7 +395,7 @@ def _interpolate_exact_poloidal_ring(
 
     ## This comes from _select_custom_sol_ring
     # start, end = _get_poloidal_range(ds, region)   
-    poloidal_selection = m["poloidal_slices"][region]
+    poloidal_selection = xhermes.selector_poloidal(ds, region)
     poloidal_indices = ds["theta_idx"].values[poloidal_selection]
 
     ## Get radial slice to figure out field line starting point based on sepdist
@@ -502,6 +509,11 @@ def get_1d_poloidal_data(
     target_first : bool, if True, reverse the dataframe so that 0 distance is at the target
 
     """
+    if region == "all":
+        region = "sol"
+    elif region in ["inner", "outer", "inner_lower", "inner_upper", "outer_lower", "outer_upper"]:
+        region = f"{region}_sol"
+
     m = ds.metadata
 
     if "t" in ds.sizes:
@@ -623,7 +635,7 @@ def get_1d_poloidal_data(
 
     if "sol" in region:
         xpoint_index_name = f"{region.replace("_sol", "")}_xpoint"
-        global_xpoint_index = m["poloidal_slices"][xpoint_index_name]
+        global_xpoint_index = xhermes.selector_poloidal(ds, xpoint_index_name)
 
         Xpoint_index = df[df["theta_idx"] == global_xpoint_index].index[0]
 


### PR DESCRIPTION
- New tool sdtools.code_comparison.interpolate.interpolateSOLPStoHermes which does what the name suggests on a per field line basis
- Make sdtools use all selections/regions from xHermes (https://github.com/boutproject/xhermes/pull/28). You will need to update xhermes.
- get_1d_radial_data works for a specified poloidal index in SOLPS and Hermes-3.
- get_1d_poloidal_data interpolates the field line to the correct sepdist using psi instead of the radial distance fraction.
- SOLPScase now reads `b2fgmtry` which includes psi and other useful arrays.
